### PR TITLE
Add Google login, single-request login, grade completion page

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,2 @@
 VITE_API_URL=http://localhost:8000
+VITE_GOOGLE_CLIENT_ID=161107240389-9q9viaqdig0vmehe3gahnkqte3s4d3c5.apps.googleusercontent.com

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 VITE_API_URL=https://satduel-e07814415d4e.herokuapp.com
+VITE_GOOGLE_CLIENT_ID=161107240389-9q9viaqdig0vmehe3gahnkqte3s4d3c5.apps.googleusercontent.com

--- a/src/components/GoogleLogin.jsx
+++ b/src/components/GoogleLogin.jsx
@@ -1,34 +1,65 @@
 import React from 'react';
-import { GoogleOAuthProvider, GoogleLogin } from '@react-oauth/google';
+import {GoogleOAuthProvider, GoogleLogin} from '@react-oauth/google';
+import {message} from 'antd';
 import axios from 'axios';
+import {useNavigate} from 'react-router-dom';
+import {useAuth} from '../context/AuthContext';
 
+const CLIENT_ID =
+    import.meta.env.VITE_GOOGLE_CLIENT_ID ||
+    '161107240389-9q9viaqdig0vmehe3gahnkqte3s4d3c5.apps.googleusercontent.com';
+
+/**
+ * "Sign in with Google" button.
+ *
+ * Uses Google Identity Services: the button hands us a signed `credential`
+ * (id_token), which we post to the backend. The backend verifies it, links or
+ * creates the account by verified email, and returns our own JWTs.
+ */
 const GoogleLoginButton = () => {
-  const handleLoginSuccess = (credentialResponse) => {
-    axios.post('/auth/google/', {
-      access_token: credentialResponse.credential
-    }).then(res => {
-      // Handle successful login
-      console.log(res.data);
-      // You might want to store the token and redirect the user
-    }).catch(err => {
-      console.error(err);
-    });
-  };
+    const navigate = useNavigate();
+    const {login} = useAuth();
 
-  const handleLoginError = () => {
-    console.error('Login Failed');
-  };
+    const handleSuccess = async (credentialResponse) => {
+        try {
+            const baseUrl = import.meta.env.VITE_API_URL;
+            const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+            const {data} = await axios.post(`${baseUrl}/api/auth/google/`, {
+                credential: credentialResponse.credential,
+                timezone: userTimezone,
+            });
 
-  return (
-    <GoogleOAuthProvider clientId="959022396676-290ob5dbbj40o0d0rmbcods62acq4fp1.apps.googleusercontent.com">
-      <GoogleLogin
-        onSuccess={handleLoginSuccess}
-        onError={handleLoginError}
-        useOneTap
-        auto_select
-      />
-    </GoogleOAuthProvider>
-  );
+            await login(data.user, data.access, data.refresh);
+
+            if (data.user.is_new_user) {
+                navigate('/complete_profile');
+            } else if (data.user.is_first_login) {
+                navigate('/goal_setting');
+            } else {
+                navigate('/');
+            }
+        } catch (error) {
+            const msg = error.response?.data?.error || 'Google sign-in failed. Please try again.';
+            message.error(msg);
+        }
+    };
+
+    const handleError = () => {
+        message.error('Google sign-in was cancelled or failed.');
+    };
+
+    return (
+        <GoogleOAuthProvider clientId={CLIENT_ID}>
+            <div style={{display: 'flex', justifyContent: 'center'}}>
+                <GoogleLogin
+                    onSuccess={handleSuccess}
+                    onError={handleError}
+                    useOneTap={false}
+                    width="300"
+                />
+            </div>
+        </GoogleOAuthProvider>
+    );
 };
 
 export default GoogleLoginButton;

--- a/src/components/Router.jsx
+++ b/src/components/Router.jsx
@@ -2,6 +2,7 @@ import React, {Suspense} from 'react';
 import {Route, Routes} from "react-router-dom";
 import SecondaryLayout from "../layout/SecondaryLayout";
 import GoalSettingPage from "../pages/GoalSettingPage";
+import CompleteProfilePage from "../pages/CompleteProfilePage";
 
 // Lazy load components
 const HomePage = React.lazy(() => import("../pages/HomePage"));
@@ -430,6 +431,11 @@ function Router() {
                         <GoalSettingPage/>
                     </Suspense>
                 }
+            />
+
+            <Route
+                path="/complete_profile"
+                element={<CompleteProfilePage/>}
             />
         </Routes>
     );

--- a/src/pages/CompleteProfilePage.jsx
+++ b/src/pages/CompleteProfilePage.jsx
@@ -1,0 +1,87 @@
+import React, {useState} from 'react';
+import styled from 'styled-components';
+import {Card, Typography, Select, Button, message} from 'antd';
+import {useNavigate} from 'react-router-dom';
+import api from '../components/api';
+
+const {Title, Text} = Typography;
+const {Option} = Select;
+
+const FullScreenContainer = styled.div`
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #f0f4f8 0%, #e1e9f0 100%);
+    padding: 1rem;
+    box-sizing: border-box;
+`;
+
+const StyledCard = styled(Card)`
+    width: 420px;
+    max-width: 100%;
+    border-radius: 16px;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+    text-align: center;
+`;
+
+/**
+ * Shown after a new Google signup: collects the one field Google can't give us
+ * (grade), then continues into the normal first-login goal-setting flow.
+ */
+const CompleteProfilePage = () => {
+    const [grade, setGrade] = useState(null);
+    const [submitting, setSubmitting] = useState(false);
+    const navigate = useNavigate();
+
+    const handleSubmit = async () => {
+        if (!grade) {
+            message.warning('Please select your grade.');
+            return;
+        }
+        setSubmitting(true);
+        try {
+            await api.post('api/auth/complete_profile/', {grade});
+            navigate('/goal_setting');
+        } catch (e) {
+            message.error(e.response?.data?.error || 'Could not save your grade. Please try again.');
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <FullScreenContainer>
+            <StyledCard>
+                <Title level={2} style={{marginBottom: '0.25rem'}}>Welcome to SAT Duel!</Title>
+                <Text type="secondary">One quick thing — what grade are you in?</Text>
+                <div style={{margin: '1.5rem 0'}}>
+                    <Select
+                        placeholder="Select Grade"
+                        style={{width: '100%'}}
+                        size="large"
+                        value={grade}
+                        onChange={setGrade}
+                    >
+                        <Option value="<1">{'<1'}</Option>
+                        {[...Array(12)].map((_, i) => (
+                            <Option key={i + 1} value={String(i + 1)}>{i + 1}</Option>
+                        ))}
+                        <Option value=">12">{'>12'}</Option>
+                    </Select>
+                </div>
+                <Button
+                    type="primary"
+                    size="large"
+                    block
+                    loading={submitting}
+                    onClick={handleSubmit}
+                >
+                    Continue
+                </Button>
+            </StyledCard>
+        </FullScreenContainer>
+    );
+};
+
+export default CompleteProfilePage;

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -2,7 +2,8 @@ import React, {useEffect, useState} from 'react';
 import axios from 'axios';
 import {Link, useNavigate} from 'react-router-dom';
 import {useAuth} from "../context/AuthContext";
-import {Form, Input, Button, Card, Typography, Space, message} from 'antd';
+import {Form, Input, Button, Card, Typography, Space, Divider, message} from 'antd';
+import GoogleLoginButton from "../components/GoogleLogin";
 
 const {Title} = Typography;
 
@@ -60,47 +61,28 @@ function Login() {
 
     const handleLogin = async () => {
         setIsSubmitting(true);
-        let userData = null;
+        setError(null);
         try {
             const baseUrl = import.meta.env.VITE_API_URL;
             const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-            const response = await axios.post(`${baseUrl}/api/login/`, {
+            // Single request: authenticate and receive tokens + user together.
+            const response = await axios.post(`${baseUrl}/api/auth/login/`, {
                 username,
                 password,
                 timezone: userTimezone
             });
-            if (response.status === 200) {
-                userData = response.data;
-            }
-        } catch (error) {
-            if (error.response && error.response.status === 401) {
-                setError('Invalid username or password');
-                message.error(error.response.data.error);
+            const {access, refresh, user: userData} = response.data;
+            await login(userData, access, refresh);
+            if (userData.is_first_login) {
+                navigate('/goal_setting');
             } else {
-                setError('An error occurred during login');
-            }
-            setIsSubmitting(false);
-            return;
-        }
-        try {
-            const baseUrl = import.meta.env.VITE_API_URL;
-            const response = await axios.post(`${baseUrl}/api/token/`, {
-                username,
-                password
-            });
-            const refreshToken = response.data.refresh;
-            if (response.status === 200) {
-                login(userData, response.data.access, refreshToken);
-                if (userData.is_first_login) {
-                    navigate('/goal_setting');
-                    return;
-                }
                 navigate('/');
-                console.log("login successful");
             }
         } catch (error) {
+            const msg = error.response?.data?.error;
             if (error.response && error.response.status === 401) {
-                setError('Invalid username or password');
+                setError(msg || 'Invalid username or password');
+                message.error(msg || 'Invalid username or password');
             } else {
                 setError('An error occurred during login');
             }
@@ -143,9 +125,9 @@ function Login() {
                         {error && <p style={errorStyle}>{error}</p>}
 
                         <Form.Item>
-                            <Button 
-                                type="primary" 
-                                htmlType="submit" 
+                            <Button
+                                type="primary"
+                                htmlType="submit"
                                 style={{width: '100%'}}
                                 loading={isSubmitting}
                                 disabled={isSubmitting}
@@ -153,6 +135,12 @@ function Login() {
                                 Login
                             </Button>
                         </Form.Item>
+
+                        <Divider plain style={{color: 'gray'}}>or</Divider>
+                        <div style={{marginBottom: '10px'}}>
+                            <GoogleLoginButton/>
+                        </div>
+
                         <Form.Item>
                             <div style={formItem}>
                                 <span style={textStyle}>Forgot your password? </span><Link to="/password_reset">Reset

--- a/src/pages/RegisterPage.jsx
+++ b/src/pages/RegisterPage.jsx
@@ -1,8 +1,9 @@
 import React, {useEffect, useState} from 'react';
-import {useNavigate} from 'react-router-dom';
+import {Link, useNavigate} from 'react-router-dom';
 import {useAuth} from '../context/AuthContext';
-import {Form, Input, Button, Card, Typography, Space, Select, message} from 'antd';
+import {Form, Input, Button, Card, Typography, Space, Select, Divider, message} from 'antd';
 import api from '../components/api';
+import GoogleLoginButton from '../components/GoogleLogin';
 
 const {Title} = Typography;
 const {Option} = Select;
@@ -188,9 +189,9 @@ function Register() {
                         {error && <p style={errorStyle}>{error}</p>}
 
                         <Form.Item>
-                            <Button 
-                                type="primary" 
-                                htmlType="submit" 
+                            <Button
+                                type="primary"
+                                htmlType="submit"
                                 style={{width: '100%'}}
                                 loading={isSubmitting}
                                 disabled={isSubmitting}
@@ -199,6 +200,13 @@ function Register() {
                             </Button>
                         </Form.Item>
                     </Form>
+
+                    <Divider plain style={{color: 'gray'}}>or</Divider>
+                    <GoogleLoginButton/>
+
+                    <div style={{textAlign: 'center', marginTop: '12px', color: 'gray'}}>
+                        Already have an account? <Link to="/login">Log in</Link>
+                    </div>
                 </Space>
             </Card>
         </div>


### PR DESCRIPTION
- GoogleLogin button rewritten: posts the Google credential (id_token) to /api/auth/google/, logs the user into AuthContext, routes new users to /complete_profile, first-login users to /goal_setting. Uses the client ID that matches the backend (VITE_GOOGLE_CLIENT_ID).
- LoginPage: one request to /api/auth/login/ instead of the /login/ + /token/ two-step; shows the Google button under an 'or' divider.
- RegisterPage: Google button + link to login.
- CompleteProfilePage: collects grade for new Google signups, then continues to goal setting.