### PR TITLE
Shrink footer to one row, add Discord community CTAs

### DIFF
--- a/src/components/Discord.jsx
+++ b/src/components/Discord.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+export const DISCORD_INVITE = 'https://discord.gg/jzZTy3cdwm';
+const DISCORD_BLURPLE = '#5865F2';
+
+export function DiscordIcon({className = 'size-5'}) {
+    // Official Discord mark (single-path, currentColor).
+    return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M20.317 4.369A19.79 19.79 0 0 0 16.558 3.2a.074.074 0 0 0-.079.037c-.34.607-.719 1.4-.984 2.023a18.28 18.28 0 0 0-5.487 0 12.6 12.6 0 0 0-.997-2.023.077.077 0 0 0-.079-.037A19.74 19.74 0 0 0 3.677 4.369a.07.07 0 0 0-.032.028C1.226 8.02.56 11.58.887 15.096a.082.082 0 0 0 .031.056 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.1 13.1 0 0 1-1.872-.892.077.077 0 0 1-.008-.128c.126-.094.252-.192.372-.291a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.009c.12.099.246.198.373.292a.077.077 0 0 1-.006.127c-.598.35-1.22.645-1.873.892a.076.076 0 0 0-.04.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.84 19.84 0 0 0 6.002-3.03.077.077 0 0 0 .032-.055c.5-4.065-.838-7.596-2.744-10.7a.06.06 0 0 0-.031-.028zM8.02 12.955c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.418 2.157-2.418 1.21 0 2.176 1.094 2.157 2.418 0 1.334-.955 2.419-2.157 2.419zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.418 2.157-2.418 1.21 0 2.176 1.094 2.157 2.418 0 1.334-.946 2.419-2.157 2.419z"/>
+        </svg>
+    );
+}
+
+/**
+ * Discord community CTA. `variant`:
+ *  - 'button'  : compact blurple button (footer, inline)
+ *  - 'banner'  : full-width card callout (login/register)
+ */
+export function DiscordCTA({variant = 'button', className = ''}) {
+    if (variant === 'banner') {
+        return (
+            <a
+                href={DISCORD_INVITE}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`flex items-center gap-3 rounded-2xl border border-[#5865F2]/20 bg-[#5865F2]/5 px-4 py-3 no-underline transition-colors hover:bg-[#5865F2]/10 ${className}`}
+            >
+                <span className="flex size-10 shrink-0 items-center justify-center rounded-xl text-white" style={{backgroundColor: DISCORD_BLURPLE}}>
+                    <DiscordIcon className="size-5"/>
+                </span>
+                <span className="min-w-0">
+                    <span className="block text-sm font-bold text-slate-900">Join our Discord</span>
+                    <span className="block text-xs text-slate-500">Study with others, get help, find duel partners.</span>
+                </span>
+            </a>
+        );
+    }
+
+    return (
+        <a
+            href={DISCORD_INVITE}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`inline-flex items-center justify-center gap-2 rounded-2xl border-2 px-4 py-2 text-[15px] font-semibold text-white no-underline transition-all active:translate-y-[3px] active:shadow-none ${className}`}
+            style={{backgroundColor: DISCORD_BLURPLE, borderColor: '#4752c4', boxShadow: '0 4px 0 0 #4752c4'}}
+        >
+            <DiscordIcon className="size-5"/> Join our Discord
+        </a>
+    );
+}
+
+export default DiscordCTA;

--- a/src/components/SATFooter.jsx
+++ b/src/components/SATFooter.jsx
@@ -1,92 +1,43 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
-import {ArrowRight, BookOpenCheck, LineChart, Swords} from 'lucide-react';
-import {Button, PageContainer} from './ui';
+import {PageContainer} from './ui';
+import {DiscordCTA} from './Discord';
 import logo from '../assets/logo192.png';
 
-const FOOTER_GROUPS = [
-    {
-        title: 'Practice',
-        links: [
-            {label: 'Daily practice', to: '/trainer'},
-            {label: 'Mini diagnostic', to: '/diagnostic'},
-            {label: 'Practice tests', to: '/practice_test'},
-        ],
-    },
-    {
-        title: 'Compete',
-        links: [
-            {label: 'Duels', to: '/match'},
-            {label: 'Tournaments', to: '/tournaments'},
-            {label: 'Rankings', to: '/ranking'},
-        ],
-    },
-    {
-        title: 'Account',
-        links: [
-            {label: 'Profile', to: '/profile'},
-            {label: 'Classes', to: '/classes'},
-            {label: 'About', to: '/about'},
-        ],
-    },
+const LINKS = [
+    {label: 'Practice', to: '/trainer'},
+    {label: 'Duels', to: '/match'},
+    {label: 'Tournaments', to: '/tournaments'},
+    {label: 'About', to: '/about'},
 ];
-
-const FooterLink = ({to, children}) => (
-    <Link to={to} className="text-sm font-medium text-slate-500 no-underline transition-colors hover:text-primary-600">
-        {children}
-    </Link>
-);
 
 const SATFooter = () => (
     <footer className="border-t border-slate-200 bg-white">
-        <PageContainer className="py-10 sm:py-12">
-            <div className="grid gap-8 lg:grid-cols-[1.3fr_2fr]">
-                <div>
-                    <Link to="/" className="inline-flex items-center gap-2 no-underline">
-                        <img src={logo} alt="SAT Duel logo" className="size-9"/>
-                        <span className="font-display text-lg font-bold text-slate-900">
-                            SAT<span className="text-primary-600">Duel</span>
-                        </span>
-                    </Link>
-                    <p className="mt-4 max-w-sm text-[15px] leading-relaxed text-slate-600">
-                        Short adaptive SAT practice, live competition, and progress tracking built around real questions.
-                    </p>
-                    <div className="mt-5 flex flex-wrap gap-2 text-xs font-semibold text-slate-600">
-                        <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1.5">
-                            <BookOpenCheck className="size-3.5"/> 1,800+ questions
-                        </span>
-                        <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1.5">
-                            <Swords className="size-3.5"/> Duels
-                        </span>
-                        <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1.5">
-                            <LineChart className="size-3.5"/> Progress
-                        </span>
-                    </div>
-                </div>
-
-                <div className="grid gap-8 sm:grid-cols-3">
-                    {FOOTER_GROUPS.map((group) => (
-                        <div key={group.title}>
-                            <h2 className="m-0 text-sm font-bold text-slate-900">{group.title}</h2>
-                            <div className="mt-3 flex flex-col gap-2.5">
-                                {group.links.map((link) => (
-                                    <FooterLink key={link.to} to={link.to}>
-                                        {link.label}
-                                    </FooterLink>
-                                ))}
-                            </div>
-                        </div>
-                    ))}
-                </div>
+        <PageContainer className="flex flex-col items-center gap-5 py-6 md:flex-row md:justify-between md:gap-4">
+            <div className="flex items-center gap-2">
+                <img src={logo} alt="SAT Duel logo" className="size-7"/>
+                <span className="font-display text-base font-bold text-slate-900">
+                    SAT<span className="text-primary-600">Duel</span>
+                </span>
             </div>
 
-            <div className="mt-10 flex flex-col gap-4 border-t border-slate-100 pt-6 sm:flex-row sm:items-center sm:justify-between">
-                <p className="m-0 text-sm text-slate-400">
-                    © {new Date().getFullYear()} SAT Duel. Built for focused SAT practice.
+            <nav className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2">
+                {LINKS.map((l) => (
+                    <Link
+                        key={l.to}
+                        to={l.to}
+                        className="text-sm font-medium text-slate-500 no-underline transition-colors hover:text-primary-600"
+                    >
+                        {l.label}
+                    </Link>
+                ))}
+            </nav>
+
+            <div className="flex items-center gap-4">
+                <DiscordCTA className="!py-1.5 !text-sm"/>
+                <p className="m-0 hidden text-sm text-slate-400 lg:block">
+                    © {new Date().getFullYear()} SAT Duel
                 </p>
-                <Button to="/diagnostic" variant="secondary" size="sm">
-                    Start diagnostic <ArrowRight className="size-4"/>
-                </Button>
             </div>
         </PageContainer>
     </footer>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -10,6 +10,7 @@ import {
     Zap,
 } from 'lucide-react';
 import {Button, Card, PageContainer} from '../components/ui';
+import {DiscordCTA} from '../components/Discord';
 import {useAuth} from '../context/AuthContext';
 
 const FEATURES = [
@@ -151,11 +152,15 @@ function HomePage() {
                     <p className="mx-auto mt-3 max-w-md text-lg text-slate-600">
                         Answer three questions and get an instant estimate of your level.
                     </p>
-                    <div className="mt-8">
+                    <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
                         <Button to="/diagnostic" size="lg">
                             Start the free diagnostic <ArrowRight className="size-5"/>
                         </Button>
+                        <DiscordCTA/>
                     </div>
+                    <p className="mt-4 text-sm text-slate-500">
+                        Or join 400+ students in our Discord community.
+                    </p>
                 </PageContainer>
             </section>
         </div>

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -4,6 +4,7 @@ import {Link, useNavigate} from 'react-router-dom';
 import {useAuth} from "../context/AuthContext";
 import {Button, Card, Field, Input, DividerLabel, Alert} from "../components/ui";
 import GoogleLoginButton from "../components/GoogleLogin";
+import {DiscordCTA} from "../components/Discord";
 
 function Login() {
     const [username, setUsername] = useState('');
@@ -104,6 +105,10 @@ function Login() {
                             Create an account
                         </Link>
                     </span>
+                </div>
+
+                <div className="mt-6">
+                    <DiscordCTA variant="banner"/>
                 </div>
             </Card>
         </div>

--- a/src/pages/RegisterPage.jsx
+++ b/src/pages/RegisterPage.jsx
@@ -4,6 +4,7 @@ import {useAuth} from '../context/AuthContext';
 import api from '../components/api';
 import {Button, Card, Field, Input, Select, DividerLabel, Alert} from '../components/ui';
 import GoogleLoginButton from '../components/GoogleLogin';
+import {DiscordCTA} from '../components/Discord';
 
 const GRADES = ['<1', ...Array.from({length: 12}, (_, i) => String(i + 1)), '>12'];
 
@@ -147,6 +148,10 @@ function Register() {
                         Log in
                     </Link>
                 </p>
+
+                <div className="mt-5">
+                    <DiscordCTA variant="banner"/>
+                </div>
             </Card>
         </div>
     );


### PR DESCRIPTION
- Footer condensed from a multi-column block to a single compact row (brand · links · Discord button · copyright); ~85px tall
- New reusable Discord component (official mark SVG, blurple, invite discord.gg/jzZTy3cdwm) with 'button' and 'banner' variants
- Discord placed at high-visibility spots: footer, login page, register page (banner), and the homepage final CTA
- All links open in a new tab with rel=noopener