### PR TITLE
Split marketing site from logged-in app shell (sidebar), relocate pri…

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,16 +1,14 @@
-import React, {useEffect, useRef, useState} from 'react';
-import {Link, NavLink, useNavigate} from 'react-router-dom';
-import {Menu, X, ChevronDown, User, LogOut, Settings} from 'lucide-react';
+import React, {useState} from 'react';
+import {Link, NavLink} from 'react-router-dom';
+import {Menu, X} from 'lucide-react';
 import {useAuth} from '../context/AuthContext';
 import logo from '../assets/logo192.png';
-import UserAvatar from './UserAvatar';
 
+// Marketing top nav (logged-out visitors). The learning experience lives in
+// the sidebar app shell, so those links are intentionally not here.
 const NAV_LINKS = [
-    {label: 'Practice', to: '/trainer'},
-    {label: 'Duel', to: '/match'},
-    {label: 'Tournaments', to: '/tournaments'},
-    {label: 'Practice Test', to: '/practice_test'},
     {label: 'Pricing', to: '/pricing'},
+    {label: 'About', to: '/about'},
 ];
 
 const navLinkClass = ({isActive}) =>
@@ -22,28 +20,8 @@ const navLinkClass = ({isActive}) =>
     ].join(' ');
 
 const Navbar = () => {
-    const {user, logout, loading} = useAuth();
-    const navigate = useNavigate();
+    const {user, loading} = useAuth();
     const [mobileOpen, setMobileOpen] = useState(false);
-    const [userMenuOpen, setUserMenuOpen] = useState(false);
-    const userMenuRef = useRef(null);
-
-    useEffect(() => {
-        const close = (e) => {
-            if (userMenuRef.current && !userMenuRef.current.contains(e.target)) {
-                setUserMenuOpen(false);
-            }
-        };
-        document.addEventListener('mousedown', close);
-        return () => document.removeEventListener('mousedown', close);
-    }, []);
-
-    const handleLogout = async () => {
-        setUserMenuOpen(false);
-        setMobileOpen(false);
-        await logout();
-        navigate('/login');
-    };
 
     return (
         <header className="sticky top-0 z-50 border-b border-slate-200 bg-white/90 backdrop-blur">
@@ -68,40 +46,12 @@ const Navbar = () => {
                 {/* Desktop auth area */}
                 <div className="hidden items-center gap-2 md:flex">
                     {!loading && user ? (
-                        <div className="relative" ref={userMenuRef}>
-                            <button
-                                onClick={() => setUserMenuOpen((o) => !o)}
-                                className="flex cursor-pointer items-center gap-2 rounded-xl border-2 border-slate-200 bg-white px-3.5 py-2 text-[15px] font-semibold text-slate-700 transition-colors hover:border-primary-300"
-                            >
-                                <UserAvatar profile={user} size="xs" className="ring-0"/>
-                                {user.username}
-                                <ChevronDown className="size-4 text-slate-400"/>
-                            </button>
-                            {userMenuOpen && (
-                                <div className="absolute right-0 mt-2 w-44 overflow-hidden rounded-xl border border-slate-200 bg-white py-1 shadow-lg">
-                                    <Link
-                                        to="/profile"
-                                        onClick={() => setUserMenuOpen(false)}
-                                        className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-slate-700 no-underline hover:bg-slate-50"
-                                    >
-                                        <User className="size-4"/> Profile
-                                    </Link>
-                                    <Link
-                                        to="/settings"
-                                        onClick={() => setUserMenuOpen(false)}
-                                        className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-slate-700 no-underline hover:bg-slate-50"
-                                    >
-                                        <Settings className="size-4"/> Settings
-                                    </Link>
-                                    <button
-                                        onClick={handleLogout}
-                                        className="flex w-full cursor-pointer items-center gap-2 px-4 py-2.5 text-sm font-medium text-rose-600 hover:bg-rose-50"
-                                    >
-                                        <LogOut className="size-4"/> Log out
-                                    </button>
-                                </div>
-                            )}
-                        </div>
+                        <Link
+                            to="/trainer"
+                            className="rounded-xl bg-primary-600 px-4 py-2 text-[15px] font-semibold text-white no-underline transition-colors hover:bg-primary-500"
+                        >
+                            Go to app
+                        </Link>
                     ) : (
                         <>
                             <Link
@@ -147,17 +97,13 @@ const Navbar = () => {
                     </div>
                     <div className="mt-3 border-t border-slate-100 pt-3">
                         {!loading && user ? (
-                            <div className="flex flex-col gap-1">
-                                <NavLink to="/profile" className={navLinkClass} onClick={() => setMobileOpen(false)}>
-                                    Profile ({user.username})
-                                </NavLink>
-                                <button
-                                    onClick={handleLogout}
-                                    className="cursor-pointer rounded-xl px-3.5 py-2 text-left text-[15px] font-semibold text-rose-600 hover:bg-rose-50"
-                                >
-                                    Log out
-                                </button>
-                            </div>
+                            <Link
+                                to="/trainer"
+                                onClick={() => setMobileOpen(false)}
+                                className="block rounded-xl bg-primary-600 px-4 py-2.5 text-center text-[15px] font-semibold text-white no-underline"
+                            >
+                                Go to app
+                            </Link>
                         ) : (
                             <div className="flex gap-2">
                                 <Link

--- a/src/components/Router.jsx
+++ b/src/components/Router.jsx
@@ -1,14 +1,15 @@
 import React, {Suspense} from 'react';
-import {Route, Routes} from "react-router-dom";
+import {Navigate, Route, Routes} from "react-router-dom";
 import SecondaryLayout from "../layout/SecondaryLayout";
+import AppLayout from "../layout/AppLayout";
 import GoalSettingPage from "../pages/GoalSettingPage";
 import CompleteProfilePage from "../pages/CompleteProfilePage";
+import {useAuth} from "../context/AuthContext";
 
 const DiagnosticPage = React.lazy(() => import("../pages/DiagnosticPage"));
 const SettingsPage = React.lazy(() => import("../pages/SettingsPage"));
 const PricingPage = React.lazy(() => import("../pages/PricingPage"));
 
-// Lazy load components
 const HomePage = React.lazy(() => import("../pages/HomePage"));
 const AboutPage = React.lazy(() => import("../pages/AboutPage"));
 const QuestionsPage = React.lazy(() => import("../pages/QuestionPage"));
@@ -51,401 +52,100 @@ const TestResultPage = React.lazy(() => import("../pages/practice_test/TestResul
 const PracticeTestPage = React.lazy(() => import("../pages/practice_test/PracticeTestPage"));
 const ClassListPage = React.lazy(() => import("../pages/classes/ClassListPage"));
 
+const Loading = () => <div className="p-8 text-center text-slate-400">Loading…</div>;
+const S = (el) => <Suspense fallback={<Loading/>}>{el}</Suspense>;
+
+// Prospects see the marketing landing page; logged-in users are pushed straight
+// into the learning experience so they don't linger on the front page.
+function HomeRoute() {
+    const {user, loading} = useAuth();
+    if (loading) return null;
+    return user ? <Navigate to="/trainer" replace/> : S(<HomePage/>);
+}
+
+// Marketing / onboarding: rendered inside the top-nav layout.
+const MARKETING_ROUTES = [
+    {path: '/login', el: <LoginPage/>},
+    {path: '/register', el: <RegisterPage/>},
+    {path: '/diagnostic', el: <DiagnosticPage/>},
+    {path: '/pricing', el: <PricingPage/>},
+    {path: '/about', el: <AboutPage/>},
+    {path: '/confirm-email/:key', el: <ConfirmEmail/>},
+    {path: '/email_verification/:email', el: <EmailVerificationPage/>},
+    {path: '/password_reset', el: <PasswordResetPage/>},
+    {path: '/api/reset/:uidb64/:token', el: <PasswordResetConfirmPage/>},
+];
+
+// The logged-in learning experience: rendered inside the sidebar app shell
+// (AppLayout gates access and redirects anonymous users to /login).
+const APP_ROUTES = [
+    {path: '/trainer', el: <TrainerPage/>},
+    {path: '/infinite_questions', el: <InfiniteQuestionPage/>},
+    {path: '/match', el: <Match/>},
+    {path: '/questions', el: <QuestionsPage/>},
+    {path: '/power_sprint_home', el: <PowerSprintHome/>},
+    {path: '/sat_survival_home', el: <SATSurvivalHomepage/>},
+    {path: '/timed_challenges', el: <TimedChallengePage/>},
+    {path: '/ranking', el: <RankingPage/>},
+    {path: '/bot_training', el: <BotTrainingPage/>},
+    {path: '/profile', el: <ProfilePage/>},
+    {path: '/profile/:userId', el: <ProfilePage/>},
+    {path: '/tournaments', el: <TournamentListPage/>},
+    {path: '/tournaments/info', el: <TournamentPage/>},
+    {path: '/tournament/:tournamentId', el: <TournamentDetailPage/>},
+    {path: '/create_tournament', el: <CreateTournamentPage/>},
+    {path: '/my_tournaments', el: <MyTournamentsPage/>},
+    {path: '/shop', el: <ShopPage/>},
+    {path: '/duels', el: <SATDuelHomePage/>},
+    {path: '/practice_test', el: <PracticeTestPage/>},
+    {path: '/classes', el: <ClassListPage/>},
+    {path: '/settings', el: <SettingsPage/>},
+    {path: '/upgrade', el: <PricingPage/>},  // in-app pricing (keeps the shell)
+    {path: '/admin', el: <AdminHomepage/>},
+    {path: '/admin/questions', el: <QuestionListPage/>},
+    {path: '/admin/create_question', el: <QuestionEditorPage/>},
+    {path: '/admin/edit_question/:id', el: <QuestionEditorPage/>},
+    {path: '/admin/create_tournament', el: <AdminCreateTournamentPage/>},
+];
+
+// Focused, distraction-free experiences: no sidebar or top nav.
+const FULLSCREEN_ROUTES = [
+    {path: '/duel_battle/:roomId', el: <DuelBattle/>},
+    {path: '/battle_result/:roomId', el: <BattleResultPage/>},
+    {path: '/match-loading/:roomId', el: <MatchLoadingPage/>},
+    {path: '/power_sprint', el: <PowerSprintPage/>},
+    {path: '/sat_survival', el: <SATSurvivalPage/>},
+    {path: '/bot_training/start', el: <BotGamePage/>},
+    {path: '/waiting-room/:gameId', el: <WaitingRoomPage/>},
+    {path: '/tournament/:tournamentId/questions', el: <TournamentQuestionPage/>},
+    {path: '/full_length_test', el: <TestPage/>},
+    {path: '/test_result', el: <TestResultPage/>},
+    {path: '/goal_setting', el: <GoalSettingPage/>},
+    {path: '/complete_profile', el: <CompleteProfilePage/>},
+];
+
 function Router() {
     return (
         <Routes>
+            {/* Marketing / onboarding */}
             <Route element={<SecondaryLayout/>}>
-                <Route
-                    path="/"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <HomePage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/login"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <LoginPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/register"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <RegisterPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/settings"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <SettingsPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/pricing"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <PricingPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/diagnostic"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <DiagnosticPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/confirm-email/:key"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <ConfirmEmail/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/email_verification/:email"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <EmailVerificationPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/password_reset"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <PasswordResetPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/api/reset/:uidb64/:token"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <PasswordResetConfirmPage/>
-                        </Suspense>
-                    }
-                />
-
-                <Route
-                    path="/about"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <AboutPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/match"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <Match/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/duel_battle/:roomId"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <DuelBattle/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/battle_result/:roomId"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <BattleResultPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/match-loading/:roomId"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <MatchLoadingPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/questions"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <QuestionsPage/>
-                        </Suspense>
-                    }
-                />
-
-                <Route
-                    path="/trainer"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <TrainerPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/infinite_questions"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <InfiniteQuestionPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/power_sprint_home"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <PowerSprintHome/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/power_sprint"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <PowerSprintPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/sat_survival_home"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <SATSurvivalHomepage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/sat_survival"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <SATSurvivalPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/timed_challenges"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <TimedChallengePage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/ranking"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <RankingPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/bot_training"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <BotTrainingPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/bot_training/start"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <BotGamePage/>
-                        </Suspense>
-                    }
-                />
-
-                <Route
-                    path="/profile"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <ProfilePage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/profile/:userId"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <ProfilePage/>
-                        </Suspense>
-                    }
-                />
-
-                <Route
-                    path="/tournaments"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <TournamentListPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/tournaments/info"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <TournamentPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/tournament/:tournamentId"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <TournamentDetailPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/tournament/:tournamentId/questions"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <TournamentQuestionPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/create_tournament"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <CreateTournamentPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/my_tournaments"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <MyTournamentsPage/>
-                        </Suspense>
-                    }
-                />
-
-                <Route
-                    path="/shop"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <ShopPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/admin"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <AdminHomepage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/admin/questions"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <QuestionListPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/admin/create_question"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <QuestionEditorPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/admin/edit_question/:id"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <QuestionEditorPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/admin/create_tournament"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <AdminCreateTournamentPage/>
-                        </Suspense>
-                    }
-                />
-
-                <Route
-                    path="/duels"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <SATDuelHomePage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/waiting-room/:gameId"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <WaitingRoomPage/>
-                        </Suspense>
-                    }
-                />
-
-                <Route
-                    path="/practice_test"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <PracticeTestPage/>
-                        </Suspense>
-                    }
-                />
-                <Route
-                    path="/classes"
-                    element={
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <ClassListPage/>
-                        </Suspense>
-                    }
-                />
+                <Route path="/" element={<HomeRoute/>}/>
+                {MARKETING_ROUTES.map((r) => (
+                    <Route key={r.path} path={r.path} element={S(r.el)}/>
+                ))}
             </Route>
 
-            <Route
-                path="/full_length_test"
-                element={
-                    <Suspense fallback={<div>Loading...</div>}>
-                        <TestPage/>
-                    </Suspense>
-                }
-            />
-            <Route
-                path="/test_result"
-                element={
-                    <Suspense fallback={<div>Loading...</div>}>
-                        <TestResultPage/>
-                    </Suspense>
-                }
-            />
+            {/* Logged-in app shell */}
+            <Route element={<AppLayout/>}>
+                {APP_ROUTES.map((r) => (
+                    <Route key={r.path} path={r.path} element={S(r.el)}/>
+                ))}
+            </Route>
 
-            <Route
-                path="/goal_setting"
-                element={
-                    <Suspense fallback={<div>Loading...</div>}>
-                        <GoalSettingPage/>
-                    </Suspense>
-                }
-            />
-
-            <Route
-                path="/complete_profile"
-                element={<CompleteProfilePage/>}
-            />
+            {/* Fullscreen focused flows */}
+            {FULLSCREEN_ROUTES.map((r) => (
+                <Route key={r.path} path={r.path} element={S(r.el)}/>
+            ))}
         </Routes>
     );
 }

--- a/src/layout/AppLayout.jsx
+++ b/src/layout/AppLayout.jsx
@@ -1,0 +1,239 @@
+import React, {useState} from 'react';
+import {Navigate, NavLink, Outlet, useNavigate} from 'react-router-dom';
+import {
+    Home,
+    Zap,
+    Swords,
+    Trophy,
+    ClipboardList,
+    Medal,
+    Settings,
+    LogOut,
+    Crown,
+    Menu,
+    X,
+} from 'lucide-react';
+import {useAuth} from '../context/AuthContext';
+import UserAvatar from '../components/UserAvatar';
+import {Spinner} from '../components/ui';
+import logo from '../assets/logo192.png';
+
+// The learning experience lives behind these. Order = importance.
+const NAV_ITEMS = [
+    {label: 'Home', to: '/trainer', icon: Home},
+    {label: 'Practice', to: '/infinite_questions', icon: Zap},
+    {label: 'Duel', to: '/match', icon: Swords},
+    {label: 'Tournaments', to: '/tournaments', icon: Trophy},
+    {label: 'Practice Test', to: '/practice_test', icon: ClipboardList},
+    {label: 'Leaderboard', to: '/ranking', icon: Medal},
+];
+
+// Items shown in the mobile bottom bar (a focused subset).
+const MOBILE_ITEMS = [
+    {label: 'Home', to: '/trainer', icon: Home},
+    {label: 'Practice', to: '/infinite_questions', icon: Zap},
+    {label: 'Duel', to: '/match', icon: Swords},
+    {label: 'Tournaments', to: '/tournaments', icon: Trophy},
+];
+
+const sidebarLinkClass = ({isActive}) =>
+    [
+        'flex items-center gap-3 rounded-xl px-3.5 py-2.5 text-[15px] font-semibold no-underline transition-colors',
+        isActive
+            ? 'bg-primary-50 text-primary-700'
+            : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900',
+    ].join(' ');
+
+function ProfileFooter({user, onLogout, onNavigate}) {
+    return (
+        <div className="border-t border-slate-100 p-3">
+            {!user?.is_premium ? (
+                <NavLink
+                    to="/upgrade"
+                    onClick={onNavigate}
+                    className="mb-3 flex items-center gap-2.5 rounded-xl border border-amber-200 bg-gradient-to-r from-amber-50 to-amber-100/50 px-3.5 py-2.5 no-underline transition-colors hover:from-amber-100 hover:to-amber-100"
+                >
+                    <Crown className="size-5 text-amber-500"/>
+                    <span className="text-sm font-bold text-amber-900">Upgrade to Premium</span>
+                </NavLink>
+            ) : (
+                <div className="mb-3 flex items-center gap-2 rounded-xl bg-gradient-to-r from-primary-50 to-primary-100/50 px-3.5 py-2.5">
+                    <Crown className="size-5 text-primary-600"/>
+                    <span className="text-sm font-bold text-primary-800">Premium member</span>
+                </div>
+            )}
+
+            <NavLink
+                to="/profile"
+                onClick={onNavigate}
+                className="flex items-center gap-3 rounded-xl px-2 py-2 no-underline transition-colors hover:bg-slate-100"
+            >
+                <UserAvatar
+                    backgroundId={user?.avatar}
+                    iconId={user?.avatar_icon}
+                    profile={{username: user?.username}}
+                    size="sm"
+                    className="ring-2"
+                />
+                <div className="min-w-0 flex-1">
+                    <p className="m-0 truncate text-sm font-bold text-slate-900">{user?.username}</p>
+                    <p className="m-0 text-xs text-slate-400">View profile</p>
+                </div>
+            </NavLink>
+
+            <div className="mt-1 flex gap-1">
+                <NavLink
+                    to="/settings"
+                    onClick={onNavigate}
+                    className="flex flex-1 items-center justify-center gap-1.5 rounded-xl px-2 py-2 text-sm font-medium text-slate-500 no-underline transition-colors hover:bg-slate-100 hover:text-slate-800"
+                >
+                    <Settings className="size-4"/> Settings
+                </NavLink>
+                <button
+                    onClick={onLogout}
+                    className="flex flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-xl px-2 py-2 text-sm font-medium text-rose-500 transition-colors hover:bg-rose-50"
+                >
+                    <LogOut className="size-4"/> Log out
+                </button>
+            </div>
+        </div>
+    );
+}
+
+const AppLayout = () => {
+    const {user, loading, logout} = useAuth();
+    const navigate = useNavigate();
+    const [drawerOpen, setDrawerOpen] = useState(false);
+
+    // Auth gate for the whole learning experience.
+    if (loading) {
+        return (
+            <div className="flex min-h-screen items-center justify-center bg-slate-50">
+                <Spinner/>
+            </div>
+        );
+    }
+    if (!user) {
+        return <Navigate to="/login" replace/>;
+    }
+
+    const handleLogout = async () => {
+        setDrawerOpen(false);
+        await logout();
+        navigate('/login');
+    };
+
+    const closeDrawer = () => setDrawerOpen(false);
+
+    const SidebarContent = (
+        <div className="flex h-full flex-col">
+            <div className="flex h-16 items-center justify-between px-5">
+                <NavLink to="/trainer" onClick={closeDrawer} className="flex items-center gap-2 no-underline">
+                    <img src={logo} alt="SAT Duel" className="size-8"/>
+                    <span className="font-display text-lg font-bold text-slate-900">
+                        SAT<span className="text-primary-600">Duel</span>
+                    </span>
+                </NavLink>
+                <button
+                    className="rounded-lg p-1.5 text-slate-500 hover:bg-slate-100 lg:hidden"
+                    onClick={closeDrawer}
+                    aria-label="Close menu"
+                >
+                    <X className="size-5"/>
+                </button>
+            </div>
+
+            <nav className="flex-1 space-y-1 overflow-y-auto px-3 py-2">
+                {NAV_ITEMS.map(({label, to, icon: Icon}) => (
+                    <NavLink key={to} to={to} onClick={closeDrawer} className={sidebarLinkClass} end={to === '/trainer'}>
+                        <Icon className="size-5"/> {label}
+                    </NavLink>
+                ))}
+            </nav>
+
+            <ProfileFooter user={user} onLogout={handleLogout} onNavigate={closeDrawer}/>
+        </div>
+    );
+
+    return (
+        <div className="min-h-screen bg-slate-50">
+            {/* Desktop sidebar */}
+            <aside className="fixed inset-y-0 left-0 z-40 hidden w-60 border-r border-slate-200 bg-white lg:block">
+                {SidebarContent}
+            </aside>
+
+            {/* Mobile top bar */}
+            <header className="sticky top-0 z-30 flex h-14 items-center justify-between border-b border-slate-200 bg-white px-4 lg:hidden">
+                <NavLink to="/trainer" className="flex items-center gap-2 no-underline">
+                    <img src={logo} alt="SAT Duel" className="size-7"/>
+                    <span className="font-display text-base font-bold text-slate-900">
+                        SAT<span className="text-primary-600">Duel</span>
+                    </span>
+                </NavLink>
+                <button
+                    className="rounded-lg p-1.5 text-slate-600 hover:bg-slate-100"
+                    onClick={() => setDrawerOpen(true)}
+                    aria-label="Open menu"
+                >
+                    <Menu className="size-6"/>
+                </button>
+            </header>
+
+            {/* Mobile drawer */}
+            {drawerOpen && (
+                <div className="fixed inset-0 z-50 lg:hidden">
+                    <div className="absolute inset-0 bg-slate-900/40" onClick={closeDrawer}/>
+                    <div className="absolute inset-y-0 left-0 w-72 max-w-[85vw] bg-white shadow-xl">
+                        {SidebarContent}
+                    </div>
+                </div>
+            )}
+
+            {/* Content */}
+            <div className="lg:pl-60">
+                <main className="pb-20 lg:pb-0">
+                    <Outlet/>
+                </main>
+            </div>
+
+            {/* Mobile bottom tab bar */}
+            <nav className="fixed inset-x-0 bottom-0 z-30 flex border-t border-slate-200 bg-white lg:hidden">
+                {MOBILE_ITEMS.map(({label, to, icon: Icon}) => (
+                    <NavLink
+                        key={to}
+                        to={to}
+                        end={to === '/trainer'}
+                        className={({isActive}) =>
+                            [
+                                'flex flex-1 flex-col items-center gap-0.5 py-2.5 text-[11px] font-semibold no-underline transition-colors',
+                                isActive ? 'text-primary-600' : 'text-slate-400',
+                            ].join(' ')
+                        }
+                    >
+                        <Icon className="size-5"/> {label}
+                    </NavLink>
+                ))}
+                <NavLink
+                    to="/profile"
+                    className={({isActive}) =>
+                        [
+                            'flex flex-1 flex-col items-center gap-0.5 py-2.5 text-[11px] font-semibold no-underline transition-colors',
+                            isActive ? 'text-primary-600' : 'text-slate-400',
+                        ].join(' ')
+                    }
+                >
+                    <UserAvatar
+                        backgroundId={user?.avatar}
+                        iconId={user?.avatar_icon}
+                        profile={{username: user?.username}}
+                        size="xs"
+                        className="ring-0 !size-5"
+                    />
+                    Profile
+                </NavLink>
+            </nav>
+        </div>
+    );
+};
+
+export default AppLayout;


### PR DESCRIPTION
…cing

The learning experience is now encapsulated so returning users land in the app, not the marketing page:

- New AppLayout: left sidebar on desktop (Home/Practice/Duel/Tournaments/ Practice Test/Leaderboard), mobile drawer + bottom tab bar. Gates access — anonymous users hitting an app route go to /login.
- Router split into three groups: marketing (top nav), app (sidebar), and fullscreen focused flows (duel battle, test taking, onboarding).
- Logged-in users hitting / are redirected to /trainer (can't linger on the marketing landing page). Marketing home only renders for logged-out visitors.
- Pricing removed from the top nav. In the app it's an 'Upgrade to Premium' button in the sidebar footer next to the profile chip (premium members see a badge instead); it opens /upgrade which keeps the app shell. Public /pricing stays for marketing.
- Marketing navbar trimmed to Pricing + About with Login/Get started (or 'Go to app' when logged in); removed the now-unused user dropdown.