### PR TITLE
Declutter learning pages: strip marketing chrome, put content first

### DIFF
--- a/src/pages/HomeDashboard.jsx
+++ b/src/pages/HomeDashboard.jsx
@@ -278,17 +278,10 @@ function HomeDashboard() {
         <div className="sat-bubble-field min-h-screen py-6 sm:py-8">
             <PageContainer>
                 {/* Greeting */}
-                <div className="mb-6 rounded-[1.75rem] border border-slate-200 bg-white/85 p-4 shadow-sm backdrop-blur sm:p-5">
-                    <div className="flex flex-wrap items-center justify-between gap-3">
-                    <div>
-                        <span className="inline-flex items-center gap-2 rounded-full bg-slate-950 px-3 py-1 text-xs font-black uppercase text-white">
-                            <CircleDot className="size-3.5 text-cyan-300"/> Arena dashboard
-                        </span>
-                        <h1 className="m-0 mt-4 font-display text-2xl font-bold text-slate-900 sm:text-3xl">
-                            {greeting()}, {user?.username}
-                        </h1>
-                        <p className="m-0 mt-1 text-slate-500">Start with today’s reps, then watch your Elo move.</p>
-                    </div>
+                <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+                    <h1 className="m-0 font-display text-2xl font-bold text-slate-900 sm:text-3xl">
+                        {greeting()}, {user?.username}
+                    </h1>
                     <div className="flex items-center gap-2">
                         <span className="inline-flex items-center gap-1.5 rounded-full border border-orange-200 bg-orange-50 px-3.5 py-1.5 text-sm font-bold text-orange-700">
                             <Flame className="size-4"/> {data.loginStreak} day streak
@@ -298,7 +291,6 @@ function HomeDashboard() {
                                 <Crown className="size-4"/> Premium
                             </span>
                         )}
-                    </div>
                     </div>
                 </div>
 
@@ -324,10 +316,7 @@ function HomeDashboard() {
                             </div>
 
                             <div className="flex-1">
-                                <span className="inline-flex items-center gap-1.5 rounded-full border border-primary-200 bg-white px-3 py-1 text-xs font-black text-primary-700 shadow-sm">
-                                    <BookOpenCheck className="size-3.5"/> Today’s lane
-                                </span>
-                                <h2 className="m-0 mt-2 font-display text-2xl font-black text-slate-950">
+                                <h2 className="m-0 font-display text-2xl font-black text-slate-950">
                                     Daily Focused Practice
                                 </h2>
                                 <p className="m-0 mt-1 text-[15px] text-slate-600">

--- a/src/pages/RankingPage.jsx
+++ b/src/pages/RankingPage.jsx
@@ -224,15 +224,9 @@ function RankingPage() {
             <PageContainer>
                 <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
                     <div>
-                        <span className={`inline-flex items-center gap-1.5 rounded-full border px-3.5 py-1 text-sm font-semibold ${config.accent}`}>
-                            <Icon className="size-4"/> Leaderboard
-                        </span>
-                        <h1 className="m-0 mt-4 font-display text-3xl font-black text-slate-900 sm:text-4xl">
-                            Global student rankings
+                        <h1 className="m-0 font-display text-2xl font-bold text-slate-900 sm:text-3xl">
+                            Leaderboard
                         </h1>
-                        <p className="mt-2 max-w-2xl text-slate-600">
-                            Ratings and streaks from real SAT Duel practice and duels.
-                        </p>
                     </div>
                     <Button to="/infinite_questions" variant="secondary">
                         Practice now <ArrowUpRight className="size-4"/>

--- a/src/pages/TournamentListPage.jsx
+++ b/src/pages/TournamentListPage.jsx
@@ -113,22 +113,12 @@ function TournamentListPage() {
                     </div>
                 )}
 
-                <section className="sat-arena-card overflow-hidden rounded-[1.75rem] border border-slate-200 bg-white">
-                    <div className="sat-duel-lanes relative overflow-hidden bg-slate-950 px-5 py-8 text-white sm:px-8 sm:py-10">
-                        <div className="relative max-w-3xl">
-                            <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3.5 py-1.5 text-sm font-black text-cyan-200">
-                                <Trophy className="size-4"/> Tournament arena
-                            </span>
-                            <h1 className="m-0 mt-5 font-display text-4xl font-black leading-tight sm:text-5xl">
-                                Timed rounds, shared pressure, honest rankings.
-                            </h1>
-                            <p className="m-0 mt-4 max-w-2xl text-lg leading-relaxed text-slate-300">
-                                Join a tournament when you want practice to feel like an event, not another loose question session.
-                            </p>
-                        </div>
-                    </div>
+                <section>
+                    <h1 className="mb-6 font-display text-2xl font-bold text-slate-900 sm:text-3xl">
+                        Tournaments
+                    </h1>
 
-                    <div className="grid gap-3 border-t border-slate-200 bg-white p-4 sm:grid-cols-3 sm:p-5">
+                    <div className="grid gap-3 sm:grid-cols-3">
                         {INFO_CARDS.map(({title, description, icon: Icon}) => (
                             <div key={title} className="rounded-2xl bg-slate-50 p-4">
                                 <Icon className="size-5 text-primary-600"/>

--- a/src/pages/practice_test/PracticeTestPage.jsx
+++ b/src/pages/practice_test/PracticeTestPage.jsx
@@ -133,23 +133,10 @@ function PracticeTestPage() {
 
     return (
         <div className="sat-bubble-field min-h-[calc(100vh-4rem)]">
-            <section className="sat-arena-surface border-b border-slate-200">
-                <PageContainer className="py-12 sm:py-16">
-                    <div className="mx-auto max-w-3xl text-center">
-                        <span className="inline-flex items-center gap-2 rounded-full bg-slate-950 px-4 py-2 text-sm font-black text-white">
-                            <BookOpenCheck className="size-4 text-cyan-300"/> Practice tests
-                        </span>
-                        <h1 className="m-0 mt-5 font-display text-4xl font-black leading-tight text-slate-950 sm:text-5xl">
-                            Simulate the SAT when you need a real checkpoint.
-                        </h1>
-                        <p className="m-0 mt-4 text-lg leading-relaxed text-slate-600">
-                            Practice tests are for measuring. Daily practice is for improving. Keep this page calm, serious, and easy to start.
-                        </p>
-                    </div>
-                </PageContainer>
-            </section>
-
-            <PageContainer className="py-10 sm:py-14">
+            <PageContainer className="py-8 sm:py-12">
+                <h1 className="mb-6 font-display text-2xl font-bold text-slate-900 sm:text-3xl">
+                    Practice Tests
+                </h1>
                 {showFirstRunBanner && (
                     <div className="mb-6">
                         <Alert type="success">

--- a/src/pages/trainer/InfiniteQuestionPage.jsx
+++ b/src/pages/trainer/InfiniteQuestionPage.jsx
@@ -276,16 +276,11 @@ function InfiniteQuestionsPage() {
     return (
         <div className="sat-bubble-field min-h-[calc(100vh-4rem)] py-8 sm:py-12">
             <PageContainer>
-                <div className="mb-8 rounded-[1.75rem] border border-slate-200 bg-white/85 p-5 shadow-sm sm:p-6">
-                    <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-950 px-3.5 py-1.5 text-sm font-black text-white">
-                        <LineChart className="size-4"/> Adaptive practice
+                <div className="mb-5 flex flex-wrap items-baseline justify-between gap-2">
+                    <h1 className="m-0 font-display text-2xl font-bold text-slate-900">Practice</h1>
+                    <span className="text-sm font-medium text-slate-400">
+                        Question {stats.questionsAnswered + 1}
                     </span>
-                    <h1 className="m-0 mt-4 font-display text-3xl font-black text-slate-950 sm:text-4xl">
-                        Daily SAT question practice
-                    </h1>
-                    <p className="mt-2 max-w-2xl text-slate-600">
-                        Answer one question at a time. Your practice Elo updates live after each first attempt.
-                    </p>
                 </div>
 
                 <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">


### PR DESCRIPTION
Turn the logged-in learning environment from a marketing-site look into an actual study app. Across the core pages, removed the eyebrow 'pill' above headings, the heavy black (bg-slate-950) label pills, oversized hero headings, and explanatory filler paragraphs — so the question/content is front and center.

- Practice: black 'Adaptive practice' pill + 'answer one at a time...' blurb → slim 'Practice / Question N' header; question is now the hero
- Home dashboard: dropped the black 'Arena dashboard' pill, the greeting card wrapper, the 'watch your Elo move' subtitle, and the 'Today's lane' eyebrow
- Leaderboard: eyebrow + 'Global student rankings' + blurb → 'Leaderboard'
- Tournaments: dark marketing hero ('Timed rounds, shared pressure...') → plain 'Tournaments' header
- Practice Test: black pill + 'Simulate the SAT...' hero + blurb → 'Practice Tests' header

Landing page intentionally left untouched.