### PR TITLE
Cut AI-flavored filler from learning pages; content first, help last

### DIFF
--- a/src/pages/MyTournamentsPage.jsx
+++ b/src/pages/MyTournamentsPage.jsx
@@ -42,15 +42,7 @@ function MyTournamentsPage() {
                 )}
 
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-                    <div>
-                        <span className="inline-flex items-center gap-2 rounded-full bg-slate-950 px-3.5 py-1.5 text-sm font-black text-white">
-                            <Trophy className="size-4 text-amber-300"/> Host console
-                        </span>
-                        <h1 className="m-0 mt-4 font-display text-4xl font-black text-slate-950">My tournaments</h1>
-                        <p className="m-0 mt-2 max-w-2xl text-slate-500">
-                            Manage the private and classroom rounds you created.
-                        </p>
-                    </div>
+                    <h1 className="m-0 font-display text-2xl font-bold text-slate-900 sm:text-3xl">My tournaments</h1>
                     <Button to="/create_tournament">
                         <Plus className="size-4"/> Create tournament
                     </Button>
@@ -63,9 +55,9 @@ function MyTournamentsPage() {
                 ) : tournaments.length === 0 ? (
                     <Card className="sat-arena-card mt-8 p-8 text-center">
                         <Trophy className="mx-auto size-10 text-slate-300"/>
-                        <h2 className="m-0 mt-4 font-display text-2xl font-black text-slate-950">No tournaments created yet</h2>
+                        <h2 className="m-0 mt-4 font-display text-2xl font-black text-slate-950">Nothing here yet</h2>
                         <p className="mx-auto mt-2 max-w-md text-slate-500">
-                            Create a private round when you want a group of students to compete on one shared set.
+                            Create a tournament and share its join code with your class or friends.
                         </p>
                         <Button to="/create_tournament" className="mt-5">Create your first tournament</Button>
                     </Card>

--- a/src/pages/ShopPage.jsx
+++ b/src/pages/ShopPage.jsx
@@ -69,12 +69,9 @@ function Shop() {
     return (
         <PageContainer className="min-h-screen py-8 sm:py-10">
             <div className="mb-8 text-center">
-                <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-primary-200 bg-primary-50 px-3 py-1 text-xs font-black uppercase tracking-[0.16em] text-primary-700">
-                    <Sparkles size={14}/> Legacy Shop
-                </div>
                 <h1 className="text-4xl font-black text-slate-950 sm:text-5xl">Coin Shop</h1>
                 <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-slate-500">
-                    Pet cosmetics and old coin perks live here while the product moves toward a cleaner progress system.
+                    Spend the coins you earn from practice.
                 </p>
             </div>
 

--- a/src/pages/TournamentListPage.jsx
+++ b/src/pages/TournamentListPage.jsx
@@ -1,27 +1,9 @@
 import React, {useEffect, useState} from 'react';
-import {ArrowRight, ClipboardPenLine, DoorOpen, Info, Trophy, Users, X} from 'lucide-react';
+import {ArrowRight, DoorOpen, Info, X} from 'lucide-react';
 import {useNavigate} from 'react-router-dom';
 import api from '../components/api';
 import TournamentCard from '../components/Tournament/TournamentCard';
 import {Alert, Button, Card, Input, PageContainer, Spinner} from '../components/ui';
-
-const INFO_CARDS = [
-    {
-        title: 'Same arena, same questions',
-        description: 'Everyone works through the same tournament set, so the leaderboard feels fair and concrete.',
-        icon: Trophy,
-    },
-    {
-        title: 'Useful pressure',
-        description: 'Timed rounds add urgency without adding a pile of extra game systems to track.',
-        icon: Users,
-    },
-    {
-        title: 'Review after the round',
-        description: 'Use the leaderboard and question history to spot exactly where points were won or lost.',
-        icon: ClipboardPenLine,
-    },
-];
 
 function JoinCodeModal({open, value, onChange, onClose, onSubmit}) {
     if (!open) return null;
@@ -114,33 +96,13 @@ function TournamentListPage() {
                 )}
 
                 <section>
-                    <h1 className="mb-6 font-display text-2xl font-bold text-slate-900 sm:text-3xl">
-                        Tournaments
-                    </h1>
-
-                    <div className="grid gap-3 sm:grid-cols-3">
-                        {INFO_CARDS.map(({title, description, icon: Icon}) => (
-                            <div key={title} className="rounded-2xl bg-slate-50 p-4">
-                                <Icon className="size-5 text-primary-600"/>
-                                <p className="m-0 mt-3 font-black text-slate-950">{title}</p>
-                                <p className="m-0 mt-1 text-sm leading-relaxed text-slate-500">{description}</p>
-                            </div>
-                        ))}
-                    </div>
-                </section>
-
-                <section className="mt-10">
                     <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-                        <div>
-                            <h2 className="m-0 font-display text-2xl font-black text-slate-950">Available tournaments</h2>
-                            <p className="m-0 mt-1 text-sm text-slate-500">Pick a live or scheduled arena and compete on the same question set.</p>
-                        </div>
+                        <h1 className="m-0 font-display text-2xl font-bold text-slate-900 sm:text-3xl">
+                            Tournaments
+                        </h1>
                         <div className="flex flex-col gap-3 sm:flex-row">
                             <Button variant="secondary" onClick={() => setJoinCodeModalVisible(true)}>
-                                <DoorOpen className="size-4"/> Join private
-                            </Button>
-                            <Button to="/tournaments/info">
-                                How tournaments work <ArrowRight className="size-4"/>
+                                <DoorOpen className="size-4"/> Join with a code
                             </Button>
                         </div>
                     </div>
@@ -158,12 +120,12 @@ function TournamentListPage() {
                     ) : (
                         <Card className="sat-arena-card mt-5 p-8 text-center">
                             <Info className="mx-auto size-9 text-slate-300"/>
-                            <h3 className="m-0 mt-3 font-display text-2xl font-black text-slate-950">No public tournaments yet</h3>
+                            <h3 className="m-0 mt-3 font-display text-2xl font-black text-slate-950">No public tournaments right now</h3>
                             <p className="mx-auto mt-2 max-w-md text-slate-500">
-                                Private tournaments can still be joined with a code. Public rounds will appear here when they are available.
+                                Got a code from a teacher or friend? Join their private one.
                             </p>
                             <Button className="mt-5" variant="secondary" onClick={() => setJoinCodeModalVisible(true)}>
-                                Join with code
+                                Join with a code
                             </Button>
                         </Card>
                     )}
@@ -172,11 +134,17 @@ function TournamentListPage() {
                 <section className="mt-10 rounded-[1.5rem] border border-slate-200 bg-white p-5 sm:p-6">
                     <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                         <div>
-                            <p className="m-0 text-xs font-black uppercase text-primary-600">Hosting a class?</p>
-                            <h2 className="m-0 mt-2 font-display text-2xl font-black text-slate-950">Create a controlled tournament.</h2>
-                            <p className="m-0 mt-1 text-sm text-slate-500">Use private codes when you want a classroom or club-only leaderboard.</p>
+                            <h2 className="m-0 font-display text-2xl font-black text-slate-950">Host your own</h2>
+                            <p className="m-0 mt-1 text-sm text-slate-500">
+                                Make a private tournament and share the join code with your class or friends.
+                            </p>
                         </div>
-                        <Button to="/create_tournament">Create tournament</Button>
+                        <div className="flex flex-col gap-3 sm:flex-row">
+                            <Button to="/tournaments/info" variant="secondary">
+                                How tournaments work <ArrowRight className="size-4"/>
+                            </Button>
+                            <Button to="/create_tournament">Create tournament</Button>
+                        </div>
                     </div>
                 </section>
             </PageContainer>

--- a/src/pages/TournamentPage.jsx
+++ b/src/pages/TournamentPage.jsx
@@ -4,27 +4,27 @@ import {Button, Card, PageContainer} from '../components/ui';
 
 const FEATURES = [
     {
-        title: 'Find a round',
-        description: 'Public tournaments sit in one clean arena list. Private rounds stay accessible by code.',
+        title: '1. Join',
+        description: 'Pick a public tournament from the list, or enter a join code from a teacher or friend.',
         icon: Trophy,
     },
     {
-        title: 'Answer under pressure',
-        description: 'The timer gives practice a real test-day edge without hiding the learning goal.',
+        title: '2. Answer',
+        description: 'Everyone gets the same questions and the same clock. Once you start, the timer keeps running.',
         icon: Clock3,
     },
     {
-        title: 'Compare fairly',
-        description: 'Everyone plays the same question set, so leaderboard movement is easy to understand.',
+        title: '3. Score',
+        description: 'Correct answers score points; earlier correct answers break ties. Watch the leaderboard update as people finish.',
         icon: ShieldCheck,
     },
 ];
 
 const BENEFITS = [
-    ['Competitive focus', 'A tournament should make a practice session feel important enough to finish.'],
-    ['Community signal', 'Seeing other students working makes SAT prep feel less isolated.'],
-    ['Useful analytics', 'Score, timing, and question history point users back into targeted practice.'],
-    ['Low clutter', 'No coins or side systems. The core loop is questions, timing, leaderboard.'],
+    ['Same questions for everyone', 'Rankings are fair — no one gets an easier set.'],
+    ['Ties go to the faster player', 'If two people have equal scores, the one who answered correctly sooner ranks higher.'],
+    ['Review when you finish', 'Your answers and the correct ones are saved, so you can go over what you missed.'],
+    ['Private rounds', 'Anyone can create a tournament and share its code — handy for classes and study groups.'],
 ];
 
 function TournamentPage() {
@@ -33,14 +33,11 @@ function TournamentPage() {
             <section className="sat-arena-surface border-b border-slate-200">
                 <PageContainer className="py-12 sm:py-16">
                     <div className="mx-auto max-w-3xl text-center">
-                        <span className="inline-flex items-center gap-2 rounded-full bg-slate-950 px-4 py-2 text-sm font-black text-white">
-                            <Trophy className="size-4 text-amber-300"/> Tournament mode
-                        </span>
-                        <h1 className="m-0 mt-5 font-display text-4xl font-black leading-tight text-slate-950 sm:text-5xl">
-                            Practice with stakes, without adding noise.
+                        <h1 className="m-0 font-display text-4xl font-black leading-tight text-slate-950 sm:text-5xl">
+                            How tournaments work
                         </h1>
                         <p className="m-0 mt-4 text-lg leading-relaxed text-slate-600">
-                            SAT Duel tournaments turn a timed question set into a shared arena: same questions, same clock, clear leaderboard.
+                            Everyone answers the same timed question set. Highest score wins — ties go to whoever answered correctly first.
                         </p>
                         <div className="mt-7 flex flex-col justify-center gap-3 sm:flex-row">
                             <Button to="/tournaments" size="lg">
@@ -69,21 +66,20 @@ function TournamentPage() {
 
                 <section className="mt-12 grid gap-6 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
                     <div>
-                        <p className="m-0 text-xs font-black uppercase text-primary-600">Why it exists</p>
-                        <h2 className="m-0 mt-3 font-display text-3xl font-black leading-tight text-slate-950 sm:text-4xl">
-                            Tournaments are for motivation, not distraction.
+                        <h2 className="m-0 font-display text-3xl font-black leading-tight text-slate-950 sm:text-4xl">
+                            Before you join
                         </h2>
                         <p className="m-0 mt-4 text-lg leading-relaxed text-slate-600">
-                            The product should not make students track five currencies. Tournament mode should give them one clear reason to sit down and finish a serious round.
+                            The timer starts when you open the questions and doesn't pause — join when you have the full round free. You can review every question after you finish.
                         </p>
                     </div>
 
                     <Card className="sat-arena-card overflow-hidden">
                         <div className="sat-duel-lanes bg-slate-950 p-5 text-white">
                             <div className="flex items-center justify-between">
-                                <span className="font-black">Weekly Bubble Arena</span>
+                                <span className="font-black">A typical round</span>
                                 <span className="rounded-full bg-emerald-400/15 px-2.5 py-1 text-xs font-black text-emerald-200">
-                                    Live
+                                    Example
                                 </span>
                             </div>
                             <div className="mt-5 grid grid-cols-3 gap-2 text-center">

--- a/src/pages/practice_test/PracticeTestPage.jsx
+++ b/src/pages/practice_test/PracticeTestPage.jsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {ArrowRight, BookOpenCheck, Clock3, Info, Sparkles, Trophy} from 'lucide-react';
+import {ArrowRight, Info} from 'lucide-react';
 import {useLocation, useNavigate} from 'react-router-dom';
 import {useAuth} from '../../context/AuthContext';
 import api from '../../components/api';
@@ -9,7 +9,7 @@ const TESTS = [
     {
         id: 1,
         title: 'SAT Diagnostic Test',
-        description: 'Start here to get a quick baseline score and a cleaner next-step signal.',
+        description: '10 questions in 25 minutes. Get a starting score to measure against.',
         time: '25 minutes',
         questions: 10,
         difficulty: 'Adaptive',
@@ -30,24 +30,6 @@ const TESTS = [
         tag: 'Soon',
         comingSoon: true,
         time_seconds: 3 * 60 * 60,
-    },
-];
-
-const FEATURES = [
-    {
-        title: 'Realistic rhythm',
-        description: 'A focused test shell with timer, review marking, and section navigation.',
-        icon: Clock3,
-    },
-    {
-        title: 'Official-style questions',
-        description: 'Practice on SAT question formats without the extra game-mode clutter.',
-        icon: BookOpenCheck,
-    },
-    {
-        title: 'Result review',
-        description: 'Score first, then inspect missed questions and explanations.',
-        icon: Trophy,
     },
 ];
 
@@ -140,7 +122,7 @@ function PracticeTestPage() {
                 {showFirstRunBanner && (
                     <div className="mb-6">
                         <Alert type="success">
-                            Welcome to SAT practice. Start with the diagnostic if you want the fastest baseline.
+                            New here? The 25-minute diagnostic gives you a starting score.
                             <button
                                 type="button"
                                 onClick={closeFirstRunBanner}
@@ -152,28 +134,8 @@ function PracticeTestPage() {
                     </div>
                 )}
 
-                <div className="grid gap-4 md:grid-cols-3">
-                    {FEATURES.map(({title, description, icon: Icon}) => (
-                        <Card key={title} className="sat-arena-card p-5">
-                            <Icon className="size-6 text-primary-600"/>
-                            <h2 className="m-0 mt-4 text-lg font-black text-slate-950">{title}</h2>
-                            <p className="m-0 mt-2 text-sm leading-relaxed text-slate-500">{description}</p>
-                        </Card>
-                    ))}
-                </div>
-
-                <section className="mt-12">
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-                        <div>
-                            <p className="m-0 flex items-center gap-2 text-xs font-black uppercase text-primary-600">
-                                <Sparkles className="size-4"/> Choose your checkpoint
-                            </p>
-                            <h2 className="m-0 mt-2 font-display text-3xl font-black text-slate-950">Available practice tests</h2>
-                            <p className="m-0 mt-1 text-sm text-slate-500">Start with the shortest useful signal, then grow into full-length tests.</p>
-                        </div>
-                    </div>
-
-                    <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                <section>
+                    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
                         {TESTS.map((test) => (
                             <TestCard key={test.id} test={test} onStart={startTest}/>
                         ))}
@@ -189,9 +151,9 @@ function PracticeTestPage() {
                             <h2 className="m-0 font-display text-2xl font-black text-slate-950">Before you begin</h2>
                             <div className="mt-4 grid gap-3 md:grid-cols-3">
                                 {[
-                                    ['Choose your test', 'Use the diagnostic for a fast baseline or wait for full-length releases.'],
-                                    ['Clear your space', 'Practice tests work best when you can focus for the full timer.'],
-                                    ['Review afterward', 'The score matters less than the pattern behind your misses.'],
+                                    ['No pausing', 'The timer runs like the real test — set aside the full time before you start.'],
+                                    ["Guess, don't skip", "There's no penalty for wrong answers, so answer everything."],
+                                    ["Read your misses", "After scoring, open the explanations for what you got wrong — that's where the points are."],
                                 ].map(([title, copy]) => (
                                     <div key={title} className="rounded-2xl bg-slate-50 p-4">
                                         <p className="m-0 font-black text-slate-900">{title}</p>

--- a/src/pages/trainer/InfiniteQuestionPage.jsx
+++ b/src/pages/trainer/InfiniteQuestionPage.jsx
@@ -49,9 +49,9 @@ function RatingPulse({feedback}) {
     if (!feedback) {
         return (
             <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
-                <p className="m-0 text-sm font-bold text-slate-700">Practice Elo is live</p>
+                <p className="m-0 text-sm font-bold text-slate-700">Your rating moves with each answer</p>
                 <p className="m-0 mt-1 text-sm text-slate-500">
-                    Your first attempt at each question moves your rating.
+                    First try counts — repeats are just review.
                 </p>
             </div>
         );


### PR DESCRIPTION
The logged-in pages read like a study app now, not a product brochure:

- Tournaments: deleted the three explainer cards that sat ABOVE the list ('Useful pressure — timed rounds add urgency without adding a pile of extra game systems to track', etc). The list is first; 'Host your own' and the 'How tournaments work' link moved to the bottom. Empty state: 'Got a code from a teacher or friend? Join their private one.'
- Practice Tests: removed the top feature cards + 'CHOOSE YOUR CHECKPOINT' eyebrow + 'shortest useful signal' subtitle; tests render immediately. Bottom tips rewritten to actual advice: 'No pausing', "Guess, don't skip — there's no penalty for wrong answers", 'Read your misses'.
- /tournaments/info now genuinely explains the rules (join → answer → score, ties go to the faster correct answer, timer never pauses) instead of design-doc philosophy ('Tournaments are for motivation, not distraction', 'The product should not make students track five currencies'). Fake 'Weekly Bubble Arena · Live · 42 players' card relabeled as an example.
- Shop: removed 'LEGACY SHOP' badge and the internal-roadmap sentence ('...while the product moves toward a cleaner progress system').
- My tournaments: dropped the 'Host console' black pill + subtitle.
- Practice: rating hint rewritten ('First try counts — repeats are just review').

No styling changes — same cards, colors, and components throughout.