### PR TITLE
Leaderboard: English/Math practice switch + top-3 podium emphasis

### DIFF
--- a/src/pages/RankingPage.jsx
+++ b/src/pages/RankingPage.jsx
@@ -52,49 +52,99 @@ function secondaryLine(entry) {
     return `${grade} · ${answered} answered`;
 }
 
+// Top-three get the honors: gold / silver / bronze medallions, a tinted row,
+// a ring, and a medal or crown. Everyone else stays clean and neutral.
+const PODIUM = {
+    1: {
+        icon: Crown,
+        badge: 'bg-gradient-to-br from-amber-300 to-amber-500 text-white border-amber-300 shadow-md shadow-amber-200',
+        row: 'bg-gradient-to-r from-amber-50 to-white ring-1 ring-inset ring-amber-200',
+        value: 'text-amber-600',
+        label: '1st',
+        labelChip: 'bg-amber-100 text-amber-800',
+    },
+    2: {
+        icon: Medal,
+        badge: 'bg-gradient-to-br from-slate-300 to-slate-500 text-white border-slate-300 shadow-md shadow-slate-200',
+        row: 'bg-gradient-to-r from-slate-50 to-white ring-1 ring-inset ring-slate-200',
+        value: 'text-slate-600',
+        label: '2nd',
+        labelChip: 'bg-slate-200 text-slate-700',
+    },
+    3: {
+        icon: Medal,
+        badge: 'bg-gradient-to-br from-orange-300 to-orange-600 text-white border-orange-300 shadow-md shadow-orange-200',
+        row: 'bg-gradient-to-r from-orange-50 to-white ring-1 ring-inset ring-orange-200',
+        value: 'text-orange-600',
+        label: '3rd',
+        labelChip: 'bg-orange-100 text-orange-800',
+    },
+};
+
 function RankBadge({rank}) {
-    const podiumStyles = {
-        1: 'bg-amber-100 text-amber-800 border-amber-200',
-        2: 'bg-slate-100 text-slate-700 border-slate-200',
-        3: 'bg-orange-100 text-orange-800 border-orange-200',
-    };
+    const podium = PODIUM[rank];
+    if (podium) {
+        const Icon = podium.icon;
+        return (
+            <span className={[
+                'relative inline-flex size-11 shrink-0 flex-col items-center justify-center rounded-xl border font-black',
+                podium.badge,
+            ].join(' ')}>
+                <Icon className="size-4"/>
+                <span className="text-[11px] leading-none">{rank}</span>
+            </span>
+        );
+    }
     return (
-        <span className={[
-            'inline-flex size-10 shrink-0 items-center justify-center rounded-xl border text-sm font-black',
-            podiumStyles[rank] || 'border-slate-200 bg-white text-slate-500',
-        ].join(' ')}>
+        <span className="inline-flex size-11 shrink-0 items-center justify-center rounded-xl border border-slate-200 bg-white text-sm font-black text-slate-500">
             #{rank}
         </span>
     );
 }
 
 function LeaderboardRow({entry, metric, highlighted = false}) {
+    const podium = PODIUM[entry.rank];
+    const rowTone = highlighted
+        ? 'bg-primary-50/70'
+        : podium
+            ? podium.row
+            : 'bg-white hover:bg-slate-50';
     return (
         <Link
             to={`/profile/${entry.user.id}`}
             className={[
-                'grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 border-b border-slate-100 px-4 py-3 no-underline transition-colors last:border-b-0 sm:px-5',
-                highlighted
-                    ? 'bg-primary-50/70'
-                    : 'bg-white hover:bg-slate-50',
+                'grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 border-b border-slate-100 no-underline transition-colors last:border-b-0 sm:px-5',
+                podium ? 'px-4 py-4' : 'px-4 py-3',
+                rowTone,
             ].join(' ')}
         >
             <RankBadge rank={entry.rank}/>
             <div className="flex min-w-0 items-center gap-3">
-                <UserAvatar profile={entry} size="sm" className="ring-0"/>
+                <UserAvatar profile={entry} size={podium ? 'md' : 'sm'} className="ring-0"/>
                 <div className="min-w-0">
                     <div className="flex min-w-0 items-center gap-2">
-                        <p className="m-0 truncate font-bold text-slate-900">{entry.user.username}</p>
+                        <p className={[
+                            'm-0 truncate font-bold text-slate-900',
+                            podium ? 'text-[15px] sm:text-base' : '',
+                        ].join(' ')}>{entry.user.username}</p>
+                        {podium && (
+                            <span className={`shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-black uppercase tracking-wide ${podium.labelChip}`}>
+                                {podium.label}
+                            </span>
+                        )}
                         {entry.is_premium && <Crown className="size-4 shrink-0 text-amber-500"/>}
                     </div>
                     <p className="m-0 mt-0.5 truncate text-sm text-slate-500">{secondaryLine(entry)}</p>
                     <p className="m-0 mt-1 hidden truncate text-xs font-medium text-slate-400 sm:block">
-                        Duel {entry.elo_rating} · Practice {entry.sp_elo_rating} · Best correct streak {entry.max_streak}
+                        Duel {entry.elo_rating} · English {entry.sp_elo_rating} · Math {entry.math_elo_rating} · Best streak {entry.max_streak}
                     </p>
                 </div>
             </div>
             <div className="text-right">
-                <p className="m-0 text-lg font-black text-slate-900 sm:text-xl">{metricValue(entry, metric)}</p>
+                <p className={[
+                    'm-0 font-black sm:text-xl',
+                    podium ? `text-xl ${podium.value}` : 'text-lg text-slate-900',
+                ].join(' ')}>{metricValue(entry, metric)}</p>
                 <p className="m-0 text-xs font-bold text-slate-400">{metricUnit(metric)}</p>
             </div>
         </Link>
@@ -141,8 +191,15 @@ function EmptyState({onRetry}) {
     );
 }
 
+// Practice splits into two boards; the API metric differs from the tab id.
+function apiMetricFor(metric, practiceSubject) {
+    if (metric === 'practice' && practiceSubject === 'math') return 'practice_math';
+    return metric;
+}
+
 function RankingPage() {
     const [metric, setMetric] = useState('duel');
+    const [practiceSubject, setPracticeSubject] = useState('english');
     const [leaderboard, setLeaderboard] = useState(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
@@ -150,13 +207,14 @@ function RankingPage() {
     const config = metricConfig(metric);
     const Icon = config.icon;
     const entries = leaderboard?.entries || [];
+    const isPractice = metric === 'practice';
 
-    const fetchLeaderboard = async (nextMetric = metric) => {
+    const fetchLeaderboard = async (nextMetric = metric, nextSubject = practiceSubject) => {
         setLoading(true);
         setError(null);
         try {
             const response = await api.get('/api/leaderboard/', {
-                params: {metric: nextMetric, limit: 50},
+                params: {metric: apiMetricFor(nextMetric, nextSubject), limit: 50},
             });
             setLeaderboard(response.data);
         } catch (err) {
@@ -167,9 +225,9 @@ function RankingPage() {
     };
 
     useEffect(() => {
-        fetchLeaderboard(metric);
+        fetchLeaderboard(metric, practiceSubject);
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [metric]);
+    }, [metric, practiceSubject]);
 
     return (
         <div className="sat-bubble-field min-h-[calc(100vh-4rem)] py-6 sm:py-8">
@@ -180,7 +238,7 @@ function RankingPage() {
                             Leaderboard
                         </h1>
                         <p className="m-0 mt-1 text-sm text-slate-500">
-                            Ranked by {config.title.toLowerCase()}.
+                            Ranked by {config.title.toLowerCase()}{isPractice ? ` · ${practiceSubject === 'math' ? 'Math' : 'English'}` : ''}.
                         </p>
                     </div>
                     <Button to="/infinite_questions" variant="secondary">
@@ -237,6 +295,11 @@ function RankingPage() {
                                 <div>
                                     <h2 className="m-0 inline-flex items-center gap-2 text-lg font-black text-slate-900">
                                         <Icon className="size-5 text-slate-400"/> {config.shortLabel}
+                                        {isPractice && (
+                                            <span className="rounded-full bg-sky-50 px-2 py-0.5 text-xs font-bold text-sky-700">
+                                                {practiceSubject === 'math' ? 'Math' : 'English'}
+                                            </span>
+                                        )}
                                     </h2>
                                     <p className="m-0 mt-1 text-sm text-slate-500">
                                         Updated from practice answers and duel results.
@@ -250,13 +313,36 @@ function RankingPage() {
                         <div>
                             {entries.map((entry) => (
                                 <LeaderboardRow
-                                    key={`${metric}-${entry.user.id}`}
+                                    key={`${metric}-${practiceSubject}-${entry.user.id}`}
                                     entry={entry}
                                     metric={metric}
                                     highlighted={entry.user.id === leaderboard.current_user?.user?.id}
                                 />
                             ))}
                         </div>
+
+                        {isPractice && (
+                            <div className="flex items-center justify-center gap-3 border-t border-slate-100 px-4 py-4">
+                                <span className="text-xs font-bold uppercase tracking-wide text-slate-400">Subject</span>
+                                <div className="inline-flex rounded-xl border border-slate-200 bg-white p-1">
+                                    {[['english', 'English'], ['math', 'Math']].map(([value, label]) => (
+                                        <button
+                                            key={value}
+                                            type="button"
+                                            onClick={() => setPracticeSubject(value)}
+                                            className={[
+                                                'cursor-pointer rounded-lg px-4 py-1.5 text-sm font-bold transition-colors',
+                                                practiceSubject === value
+                                                    ? 'bg-sky-600 text-white'
+                                                    : 'text-slate-500 hover:bg-slate-50 hover:text-slate-900',
+                                            ].join(' ')}
+                                        >
+                                            {label}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
                     </Card>
                 )}
             </PageContainer>


### PR DESCRIPTION
- Practice tab gets an English/Math subject switch at the bottom of the board (not in the top tab bar); each fetches its own ranking
- Top three rows get gold/silver/bronze medallions, tinted rings, ordinal chips, and colored values so they stand apart from the rest