### PR TITLE
Gate practice behind a start screen; add quit button

### DIFF
--- a/src/pages/trainer/InfiniteQuestionPage.jsx
+++ b/src/pages/trainer/InfiniteQuestionPage.jsx
@@ -1,5 +1,6 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
-import {CheckCircle2, Crown, Flame, Lock, XCircle} from 'lucide-react';
+import {CheckCircle2, Crown, Flame, Lock, LogOut, Timer, XCircle, Zap} from 'lucide-react';
+import '../../styles/landing.css';
 import {useAuth} from '../../context/AuthContext';
 import Question from '../../components/Question';
 import withAuth from '../../hoc/withAuth';
@@ -162,7 +163,7 @@ function readPracticeStats(data = {}) {
     };
 }
 
-function AnswerFeedback({status, ratingFeedback, elo, subject, onSubjectChange, quota, topics, selectedTopic, onTopicChange, onNext, loadingQuestions}) {
+function AnswerFeedback({status, ratingFeedback, elo, subject, onSubjectChange, quota, topics, selectedTopic, onTopicChange, onNext, onQuit, loadingQuestions}) {
     const answered = status === 'Correct' || status === 'Incorrect';
     const correct = status === 'Correct';
     const Icon = correct ? CheckCircle2 : XCircle;
@@ -210,6 +211,9 @@ function AnswerFeedback({status, ratingFeedback, elo, subject, onSubjectChange, 
                     <Button onClick={onNext} disabled={loadingQuestions} className="mt-4" block>
                         Next question
                     </Button>
+                    <Button onClick={onQuit} variant="secondary" className="mt-2" block>
+                        <LogOut className="size-4"/> Quit session
+                    </Button>
                 </>
             )}
         </Card>
@@ -217,9 +221,12 @@ function AnswerFeedback({status, ratingFeedback, elo, subject, onSubjectChange, 
 }
 
 function InfiniteQuestionsPage() {
+    // 'start' gates the first fetch behind an explicit button, and Quit returns
+    // here — so no question clock runs while the user is done for the day.
+    const [phase, setPhase] = useState('start');
     const [currentQuestion, setCurrentQuestion] = useState(null);
     const [questionStatus, setQuestionStatus] = useState('Blank');
-    const [loadingQuestions, setLoadingQuestions] = useState(true);
+    const [loadingQuestions, setLoadingQuestions] = useState(false);
     const [error, setError] = useState(null);
     const [quota, setQuota] = useState(null);
     const [subject, setSubject] = useState(() =>
@@ -309,11 +316,22 @@ function InfiniteQuestionsPage() {
 
     useEffect(() => {
         if (!loading && !hasFetchedData.current) {
-            fetchNextQuestion();
             fetchPracticeStatus();
             hasFetchedData.current = true;
         }
-    }, [fetchNextQuestion, fetchPracticeStatus, loading]);
+    }, [fetchPracticeStatus, loading]);
+
+    const handleStart = () => {
+        setPhase('playing');
+        fetchNextQuestion();
+    };
+
+    const handleQuit = () => {
+        setPhase('start');
+        setCurrentQuestion(null);
+        setQuestionStatus('Blank');
+        setRatingFeedback(null);
+    };
 
     const handleTopicChange = (topic) => {
         setSelectedTopic(topic);
@@ -444,6 +462,48 @@ function InfiniteQuestionsPage() {
         );
     }
 
+    if (phase === 'start') {
+        return (
+            <div className="sat-bubble-field min-h-[calc(100vh-4rem)] py-12 sm:py-20">
+                <PageContainer className="max-w-xl">
+                    <Card className="sat-arena-card p-8 text-center sm:p-10">
+                        <h1 className="m-0 font-display text-3xl font-bold text-slate-900">Ready to practice?</h1>
+                        <div className="mx-auto mt-6 flex max-w-md flex-col gap-3 text-left">
+                            <div className="flex items-start gap-3 rounded-xl bg-slate-50 px-4 py-3">
+                                <Timer className="mt-0.5 size-5 shrink-0 text-primary-600"/>
+                                <p className="m-0 text-sm leading-relaxed text-slate-700">
+                                    Every question is timed. Aim for real Digital SAT pace — under 2 minutes each.
+                                </p>
+                            </div>
+                            <div className="flex items-start gap-3 rounded-xl bg-amber-50 px-4 py-3">
+                                <Zap className="mt-0.5 size-5 shrink-0 text-amber-500"/>
+                                <p className="m-0 text-sm leading-relaxed text-slate-700">
+                                    <strong>Speed bonus:</strong> answer correctly within 25s (English) or 45s (Math) and earn +3 extra rating.
+                                </p>
+                            </div>
+                            <div className="flex items-start gap-3 rounded-xl bg-slate-50 px-4 py-3">
+                                <LogOut className="mt-0.5 size-5 shrink-0 text-slate-500"/>
+                                <p className="m-0 text-sm leading-relaxed text-slate-700">
+                                    Done for now? Hit <strong>Quit</strong> after a question so idle time never counts against your average.
+                                </p>
+                            </div>
+                        </div>
+                        <button
+                            type="button"
+                            onClick={handleStart}
+                            className="sd-start-btn mx-auto mt-8 block w-full max-w-sm cursor-pointer rounded-2xl border-0 bg-primary-600 px-12 py-5 font-display text-xl font-bold text-white transition-colors hover:bg-primary-500"
+                        >
+                            Start practicing
+                        </button>
+                        <p className="m-0 mt-4 text-xs text-slate-400">
+                            {quota?.limit != null ? `${quota.remaining ?? quota.limit} free questions left today` : 'Unlimited practice'}
+                        </p>
+                    </Card>
+                </PageContainer>
+            </div>
+        );
+    }
+
     return (
         <div className="sat-bubble-field min-h-[calc(100vh-4rem)] py-8 sm:py-12">
             <PageContainer>
@@ -463,6 +523,7 @@ function InfiniteQuestionsPage() {
                         selectedTopic={selectedTopic}
                         onTopicChange={handleTopicChange}
                         onNext={() => fetchNextQuestion()}
+                                onQuit={handleQuit}
                         loadingQuestions={loadingQuestions}
                     />
                 </div>
@@ -493,6 +554,7 @@ function InfiniteQuestionsPage() {
                                 selectedTopic={selectedTopic}
                                 onTopicChange={handleTopicChange}
                                 onNext={() => fetchNextQuestion()}
+                                onQuit={handleQuit}
                                 loadingQuestions={loadingQuestions}
                             />
                         </div>

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -88,3 +88,32 @@
 .sd-up { animation: sdup 0.4s ease; }
 .sd-pulse { animation: sdpulse 1.4s infinite; }
 .sd-glow { animation: sdglow 2.4s infinite; }
+
+/* big tempting CTA: soft breathing glow + periodic shine sweep */
+@keyframes sdbreathe {
+    0%, 100% { transform: scale(1); box-shadow: 0 6px 22px rgba(124, 92, 240, 0.45); }
+    50% { transform: scale(1.03); box-shadow: 0 10px 32px rgba(124, 92, 240, 0.65); }
+}
+
+@keyframes sdshine {
+    0%, 55% { transform: translateX(-160%) skewX(-18deg); }
+    100% { transform: translateX(420%) skewX(-18deg); }
+}
+
+.sd-start-btn {
+    position: relative;
+    overflow: hidden;
+    animation: sdbreathe 2.2s ease-in-out infinite;
+}
+
+.sd-start-btn::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 40%;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.35), transparent);
+    animation: sdshine 2.6s infinite;
+    pointer-events: none;
+}


### PR DESCRIPTION
Practice no longer auto-serves a question on page load — a start card explains the rules in three lines (timed at real SAT pace, the speed bonus thresholds, and the quit tip) with a big breathing/shine Start button so the extra click stays tempting. After answering, a Quit session button returns to the start card, so no question clock runs while the user is done — idle time can't pollute their average time.