### PR TITLE
Make Google the primary login method

### DIFF
--- a/src/components/GoogleLogin.jsx
+++ b/src/components/GoogleLogin.jsx
@@ -54,12 +54,17 @@ const GoogleLoginButton = ({redirectTo}) => {
 
     return (
         <GoogleOAuthProvider clientId={CLIENT_ID}>
-            <div style={{display: 'flex', justifyContent: 'center'}}>
+            <div style={{display: 'flex', justifyContent: 'center', width: '100%'}}>
                 <GoogleLogin
                     onSuccess={handleSuccess}
                     onError={handleError}
                     useOneTap={false}
-                    width="300"
+                    theme="outline"
+                    size="large"
+                    shape="pill"
+                    text="continue_with"
+                    logo_alignment="center"
+                    width="400"
                 />
             </div>
         </GoogleOAuthProvider>

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -78,6 +78,10 @@ function Login() {
                     {isTournamentInvite ? 'Log in and we will take you straight to the tournament.' : 'Log in to continue your prep.'}
                 </p>
 
+                <GoogleLoginButton redirectTo={rawNext ? redirectTo : undefined}/>
+
+                <DividerLabel>or continue with email</DividerLabel>
+
                 <form onSubmit={handleLogin} className="flex flex-col gap-4">
                     <Field label="Username or email">
                         <Input
@@ -103,9 +107,6 @@ function Login() {
                         Log in
                     </Button>
                 </form>
-
-                <DividerLabel>or</DividerLabel>
-                <GoogleLoginButton redirectTo={rawNext ? redirectTo : undefined}/>
 
                 <div className="mt-6 flex flex-col gap-1 text-center text-sm text-slate-500">
                     <span>


### PR DESCRIPTION
Move the Google sign-in button above the email/password form on the login page so it reads as the default choice, and enlarge it: large size, pill (round) shape, wider (400px), 'continue with' text.