### PR TITLE
Let the practice page hide the sidebar for a wider question

### DIFF
--- a/src/components/ui/index.jsx
+++ b/src/components/ui/index.jsx
@@ -216,9 +216,11 @@ export function Spinner({className = ''}) {
     );
 }
 
-export function PageContainer({className = '', children}) {
+// `maxWidth` replaces the default cap rather than adding to it: a max-w-* in
+// `className` would collide with the default and lose on CSS order.
+export function PageContainer({className = '', maxWidth = 'max-w-6xl', children}) {
     return (
-        <div className={['mx-auto w-full max-w-6xl px-4 sm:px-6', className].join(' ')}>
+        <div className={['mx-auto w-full px-4 sm:px-6', maxWidth, className].join(' ')}>
             {children}
         </div>
     );

--- a/src/layout/AppLayout.jsx
+++ b/src/layout/AppLayout.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {createContext, useCallback, useContext, useEffect, useMemo, useState} from 'react';
 import {Helmet} from 'react-helmet';
 import {Navigate, NavLink, Outlet, useLocation, useNavigate} from 'react-router-dom';
 import {
@@ -21,6 +21,34 @@ import {DISCORD_INVITE, DiscordIcon} from '../components/Discord';
 import {Spinner} from '../components/ui';
 import logo from '../assets/logo192.png';
 import {loginPathFor} from '../utils/authRedirect';
+
+// Routes where the sidebar may be collapsed for a wider question. Scoped on
+// purpose: with the sidebar hidden the toggle is the only way back to the nav,
+// so pages that opt in must render <NavCollapseButton/>.
+const NAV_COLLAPSIBLE_ROUTES = ['/infinite_questions'];
+
+const NAV_HIDDEN_KEY = 'sd:nav-hidden';
+
+const NavCollapseContext = createContext(null);
+
+function readNavHidden() {
+    if (typeof window === 'undefined') return false;
+    try {
+        return window.localStorage.getItem(NAV_HIDDEN_KEY) === 'true';
+    } catch {
+        // Private-mode Safari and friends: fall back to the nav being shown.
+        return false;
+    }
+}
+
+/**
+ * Sidebar collapse state, shared between AppLayout and the page that owns the
+ * toggle. `canCollapse` is false off a collapsible route, so `hidden` there is
+ * remembered but not applied.
+ */
+export function useNavCollapse() {
+    return useContext(NavCollapseContext) ?? {hidden: false, canCollapse: false, toggle: () => {}};
+}
 
 // The learning experience lives behind these. Order = importance.
 const NAV_ITEMS = [
@@ -125,6 +153,27 @@ const AppLayout = () => {
     const navigate = useNavigate();
     const location = useLocation();
     const [drawerOpen, setDrawerOpen] = useState(false);
+    const [navHidden, setNavHidden] = useState(readNavHidden);
+
+    const canCollapse = NAV_COLLAPSIBLE_ROUTES.includes(location.pathname);
+    const navCollapsed = navHidden && canCollapse;
+
+    const toggleNav = useCallback(() => {
+        setNavHidden((hidden) => {
+            const next = !hidden;
+            try {
+                window.localStorage.setItem(NAV_HIDDEN_KEY, String(next));
+            } catch {
+                // Preference just won't survive the session; not worth failing the click.
+            }
+            return next;
+        });
+    }, []);
+
+    const navCollapse = useMemo(
+        () => ({hidden: navCollapsed, canCollapse, toggle: toggleNav}),
+        [navCollapsed, canCollapse, toggleNav]
+    );
 
     useEffect(() => {
         if (!user) return undefined;
@@ -204,12 +253,17 @@ const AppLayout = () => {
     );
 
     return (
+        <NavCollapseContext.Provider value={navCollapse}>
         <div className="min-h-screen bg-slate-50">
             <Helmet>
                 <title>SAT Duel</title>
             </Helmet>
             {/* Desktop sidebar */}
-            <aside className="fixed inset-y-0 left-0 z-40 hidden w-60 border-r border-slate-200 bg-white lg:block">
+            <aside
+                className={`fixed inset-y-0 left-0 z-40 hidden w-60 border-r border-slate-200 bg-white ${
+                    navCollapsed ? '' : 'lg:block'
+                }`}
+            >
                 {SidebarContent}
             </aside>
 
@@ -241,7 +295,7 @@ const AppLayout = () => {
             )}
 
             {/* Content */}
-            <div className="lg:pl-60">
+            <div className={navCollapsed ? '' : 'lg:pl-60'}>
                 <main className="pb-20 lg:pb-0">
                     <Outlet/>
                 </main>
@@ -284,6 +338,7 @@ const AppLayout = () => {
                 </NavLink>
             </nav>
         </div>
+        </NavCollapseContext.Provider>
     );
 };
 

--- a/src/pages/trainer/InfiniteQuestionPage.jsx
+++ b/src/pages/trainer/InfiniteQuestionPage.jsx
@@ -1,7 +1,8 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
-import {CheckCircle2, ChevronDown, Crown, Flame, History, Lock, LogOut, Swords, Timer, Trophy, XCircle, Zap} from 'lucide-react';
+import {CheckCircle2, ChevronDown, Crown, Flame, History, Lock, LogOut, PanelLeftClose, PanelLeftOpen, Swords, Timer, Trophy, XCircle, Zap} from 'lucide-react';
 import '../../styles/landing.css';
 import {useAuth} from '../../context/AuthContext';
+import {useNavCollapse} from '../../layout/AppLayout';
 import Question from '../../components/Question';
 import withAuth from '../../hoc/withAuth';
 import api from '../../components/api';
@@ -382,6 +383,7 @@ function readManualTimer() {
 }
 
 function InfiniteQuestionsPage() {
+    const {hidden: navHidden, toggle: toggleNav} = useNavCollapse();
     const [currentQuestion, setCurrentQuestion] = useState(null);
     const [questionStatus, setQuestionStatus] = useState('Blank');
     const [loadingQuestions, setLoadingQuestions] = useState(false);
@@ -666,12 +668,32 @@ function InfiniteQuestionsPage() {
 
     return (
         <div className="sat-bubble-field min-h-[calc(100vh-4rem)] py-8 sm:py-12">
-            <PageContainer>
+            {/* Reclaims exactly the sidebar's width (72rem + 15rem) so the card
+                grows into the space the nav left behind. */}
+            <PageContainer maxWidth={navHidden ? 'max-w-[87rem]' : 'max-w-6xl'}>
                 <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
                     <h1 className="m-0 font-display text-2xl font-bold text-slate-900">Practice</h1>
-                    <Button to="/practice-history" variant="ghost" size="sm" className="self-start sm:self-auto">
-                        <History className="size-4"/> History
-                    </Button>
+                    <div className="flex items-center gap-2 self-start sm:self-auto">
+                        {/* Wrapper owns the breakpoint: `hidden` on the Button itself
+                            would lose to its own base `inline-flex`. The sidebar only
+                            exists at lg, so the toggle shouldn't either. */}
+                        <div className="hidden lg:block">
+                            <Button
+                                onClick={toggleNav}
+                                variant="ghost"
+                                size="sm"
+                                title={navHidden ? 'Show the navigation sidebar' : 'Hide the sidebar for a wider question'}
+                                aria-pressed={navHidden}
+                            >
+                                {navHidden
+                                    ? <><PanelLeftOpen className="size-4"/> Show nav</>
+                                    : <><PanelLeftClose className="size-4"/> Hide nav</>}
+                            </Button>
+                        </div>
+                        <Button to="/practice-history" variant="ghost" size="sm">
+                            <History className="size-4"/> History
+                        </Button>
+                    </div>
                 </div>
 
                 <div className="mb-5 lg:hidden">


### PR DESCRIPTION
Adds a Hide nav / Show nav toggle beside History on the practice page. Collapsing the sidebar widens the question card by exactly the width the nav gave up (72rem -> 87rem), so the space is reclaimed rather than left as margin. The stats panel stays put, and it's all in-page — no route change.

The preference persists in localStorage but only applies on the practice route: with the sidebar hidden the toggle is the only way back to the nav, so navigating anywhere else brings it back rather than stranding you. Default is shown, and the toggle is desktop-only since the sidebar itself is.

PageContainer gains a `maxWidth` prop that replaces the default cap. A `max-w-*` passed via className collides with the built-in `max-w-6xl` and loses on CSS order, so it can't be overridden that way.