### PR TITLE
Time each practice question automatically

### DIFF
--- a/src/pages/trainer/InfiniteQuestionPage.jsx
+++ b/src/pages/trainer/InfiniteQuestionPage.jsx
@@ -369,16 +369,26 @@ export function ReadyToPractice({quota, onStart}) {
 
 const TIMER_STORAGE_KEY = 'satduel:practice-timer';
 
+const EMPTY_TIMER = {seconds: 0, running: false, startedAt: null, questionId: null};
+
+// `questionId` is what the elapsed time belongs to. It has to survive a reload
+// too, or the restored timer would look like it belongs to no question and get
+// restarted from 0.
 function readManualTimer() {
     try {
         const saved = JSON.parse(localStorage.getItem(TIMER_STORAGE_KEY));
-        if (!saved) return {seconds: 0, running: false, startedAt: null};
+        if (!saved) return EMPTY_TIMER;
         if (saved.running && saved.startedAt) {
             return {...saved, seconds: Math.max(0, Math.floor((Date.now() - saved.startedAt) / 1000))};
         }
-        return {seconds: saved.seconds || 0, running: false, startedAt: null};
+        return {
+            seconds: saved.seconds || 0,
+            running: false,
+            startedAt: null,
+            questionId: saved.questionId ?? null,
+        };
     } catch {
-        return {seconds: 0, running: false, startedAt: null};
+        return EMPTY_TIMER;
     }
 }
 
@@ -424,6 +434,19 @@ function InfiniteQuestionsPage() {
         );
         return () => clearInterval(id);
     }, [manualTimer.running]);
+
+    // Every question is timed from 0 on its own, counting as soon as it lands.
+    // Keyed on the question id rather than the fetch itself: reloading re-fetches
+    // the *same* active question, which should keep its elapsed time, not restart.
+    useEffect(() => {
+        const questionId = currentQuestion?.id;
+        if (!questionId) return;
+        setManualTimer((timer) => (
+            timer.questionId === questionId
+                ? timer
+                : {seconds: 0, running: true, startedAt: Date.now(), questionId}
+        ));
+    }, [currentQuestion?.id]);
 
     const fetchNextQuestion = useCallback(async (topic, subj) => {
         try {
@@ -503,7 +526,15 @@ function InfiniteQuestionsPage() {
     };
 
     const handleTimerReset = () => {
-        setManualTimer({seconds: 0, running: false, startedAt: null});
+        setManualTimer((timer) => ({...timer, seconds: 0, running: false, startedAt: null}));
+    };
+
+    // Stops the clock at the moment the answer is confirmed, so the reading is
+    // the solve time rather than however long the explanation was left open.
+    const freezeTimer = () => {
+        setManualTimer((timer) => (timer.running
+            ? {...timer, seconds: Math.floor((Date.now() - timer.startedAt) / 1000), running: false, startedAt: null}
+            : timer));
     };
 
     const handleTopicChange = (topic) => {
@@ -540,6 +571,7 @@ function InfiniteQuestionsPage() {
 
             const isCorrect = response.data.result === 'correct';
             setQuestionStatus(isCorrect ? 'Correct' : 'Incorrect');
+            freezeTimer();
             if (response.data.practice_stats) {
                 setStats(readPracticeStats(response.data.practice_stats));
             }


### PR DESCRIPTION
The practice timer started paused at 0 and had to be started by hand, so it was easy to forget and the reading spanned whatever you'd been doing.

Now every question is timed on its own: the clock starts the moment a question lands, freezes when the answer is confirmed so the reading is the solve time rather than however long the explanation stayed open, and starts again from 0 on the next question. Manual pause/reset still work, but a new question always starts running — the rule is the same on every question rather than depending on what you did on the last one.

The reset is keyed on the question id rather than on the fetch. A reload re-fetches the *same* active question, and that should keep its elapsed time instead of restarting; only a genuinely different question resets. This also covers topic and subject switches, which load a new question through the same path.

The clock is frozen only once the answer comes back, not on click: a failed submission leaves the question answerable, and its timer should still be running.