### PR TITLE
Add the practice filter bar UI

### DIFF
--- a/src/components/practice/PracticeFilterBar.jsx
+++ b/src/components/practice/PracticeFilterBar.jsx
@@ -1,0 +1,272 @@
+import {useEffect, useRef, useState} from 'react';
+import {BarChart3, Bookmark, Check, ChevronDown, CircleDot, FolderOpen, Lock, RotateCcw, Target} from 'lucide-react';
+
+// The filter bar for the practice page. It narrows which question the "next"
+// engine serves — by topic, difficulty level, saved state, whether the user
+// has done it before, and how they last did on it. The whole bar is a premium
+// feature, mirroring how topic selection was gated before.
+
+export const EMPTY_FILTERS = {
+    types: [],          // question types (multi-select); [] = all topics
+    levels: [],         // difficulty 1-5 (multi-select); [] = all levels
+    saved: 'all',       // all | only | exclude
+    attempted: 'all',   // all | only | exclude   (done before)
+    result: 'all',      // all | correct | incorrect
+};
+
+export function filtersActiveCount(filters) {
+    let count = 0;
+    if (filters.types.length) count += 1;
+    if (filters.levels.length) count += 1;
+    if (filters.saved !== 'all') count += 1;
+    if (filters.attempted !== 'all') count += 1;
+    if (filters.result !== 'all') count += 1;
+    return count;
+}
+
+export function filtersToParams(filters, subject) {
+    const params = {subject};
+    if (filters.types.length) params.types = filters.types.join(',');
+    if (filters.levels.length) params.levels = filters.levels.join(',');
+    if (filters.saved !== 'all') params.saved = filters.saved;
+    if (filters.attempted !== 'all') params.attempted = filters.attempted;
+    if (filters.result !== 'all') params.result = filters.result;
+    return params;
+}
+
+const LEVEL_OPTIONS = [1, 2, 3, 4, 5].map((n) => ({value: n, label: `Level ${n}`}));
+const SAVED_OPTIONS = [
+    {value: 'all', label: 'All questions'},
+    {value: 'only', label: 'Saved only'},
+    {value: 'exclude', label: 'Not saved'},
+];
+const ATTEMPTED_OPTIONS = [
+    {value: 'all', label: 'All questions'},
+    {value: 'exclude', label: 'New only'},
+    {value: 'only', label: 'Done before'},
+];
+const RESULT_OPTIONS = [
+    {value: 'all', label: 'Show all'},
+    {value: 'correct', label: 'Correct only'},
+    {value: 'incorrect', label: 'Incorrect only'},
+];
+
+// A single dropdown chip. `multi` chips carry an array value; single chips a
+// scalar. The panel closes on outside-click or Escape.
+function FilterChip({icon: Icon, label, summary, active, disabled, children}) {
+    const [open, setOpen] = useState(false);
+    const ref = useRef(null);
+
+    useEffect(() => {
+        if (!open) return undefined;
+        const onDown = (event) => {
+            if (ref.current && !ref.current.contains(event.target)) setOpen(false);
+        };
+        const onKey = (event) => {
+            if (event.key === 'Escape') setOpen(false);
+        };
+        document.addEventListener('mousedown', onDown);
+        document.addEventListener('keydown', onKey);
+        return () => {
+            document.removeEventListener('mousedown', onDown);
+            document.removeEventListener('keydown', onKey);
+        };
+    }, [open]);
+
+    return (
+        <div ref={ref} className="relative">
+            <button
+                type="button"
+                disabled={disabled}
+                onClick={() => setOpen((value) => !value)}
+                aria-expanded={open}
+                className={[
+                    'inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-semibold transition-colors',
+                    disabled
+                        ? 'cursor-not-allowed border-slate-200 bg-slate-50 text-slate-400'
+                        : active
+                            ? 'border-primary-300 bg-primary-50 text-primary-700 hover:bg-primary-100'
+                            : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50',
+                ].join(' ')}
+            >
+                <Icon className="size-4 shrink-0"/>
+                <span className="whitespace-nowrap">{label}</span>
+                {active && summary && (
+                    <span className="max-w-[10rem] truncate rounded-md bg-primary-100 px-1.5 py-0.5 text-xs font-bold text-primary-700">
+                        {summary}
+                    </span>
+                )}
+                <ChevronDown className={`size-4 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}/>
+            </button>
+            {open && !disabled && (
+                <div className="absolute left-0 top-full z-20 mt-2 w-60 rounded-xl border border-slate-200 bg-white p-1.5 shadow-lg">
+                    {children}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function OptionRow({checked, roundedFull, onClick, children}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm font-semibold text-slate-700 hover:bg-slate-50"
+        >
+            <span
+                className={[
+                    'flex size-4 shrink-0 items-center justify-center border transition-colors',
+                    roundedFull ? 'rounded-full' : 'rounded',
+                    checked ? 'border-primary-600 bg-primary-600 text-white' : 'border-slate-300 bg-white',
+                ].join(' ')}
+            >
+                {checked && <Check className="size-3"/>}
+            </span>
+            <span className="min-w-0 flex-1 truncate">{children}</span>
+        </button>
+    );
+}
+
+function MultiPanel({options, value, onChange, emptyLabel}) {
+    const toggle = (optionValue) => {
+        onChange(value.includes(optionValue)
+            ? value.filter((v) => v !== optionValue)
+            : [...value, optionValue]);
+    };
+    return (
+        <div className="max-h-72 overflow-y-auto">
+            {value.length > 0 && (
+                <button
+                    type="button"
+                    onClick={() => onChange([])}
+                    className="mb-1 flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-xs font-bold uppercase tracking-wide text-slate-400 hover:bg-slate-50 hover:text-slate-600"
+                >
+                    <RotateCcw className="size-3.5"/> Clear ({value.length})
+                </button>
+            )}
+            {options.length === 0 && (
+                <p className="px-2.5 py-2 text-sm text-slate-400">{emptyLabel}</p>
+            )}
+            {options.map((option) => (
+                <OptionRow
+                    key={option.value}
+                    checked={value.includes(option.value)}
+                    onClick={() => toggle(option.value)}
+                >
+                    {option.label}
+                </OptionRow>
+            ))}
+        </div>
+    );
+}
+
+function SinglePanel({options, value, onChange}) {
+    return (
+        <div>
+            {options.map((option) => (
+                <OptionRow
+                    key={option.value}
+                    roundedFull
+                    checked={value === option.value}
+                    onClick={() => onChange(option.value)}
+                >
+                    {option.label}
+                </OptionRow>
+            ))}
+        </div>
+    );
+}
+
+export default function PracticeFilterBar({filters, onChange, topics, isPremium}) {
+    const set = (patch) => onChange({...filters, ...patch});
+    const locked = !isPremium;
+
+    const topicOptions = (topics || []).map((t) => ({value: t, label: t}));
+    const topicSummary = filters.types.length
+        ? (filters.types.length === 1 ? filters.types[0] : `${filters.types.length} topics`)
+        : '';
+    const levelSummary = filters.levels.length
+        ? filters.levels.slice().sort().join(', ')
+        : '';
+    const singleSummary = (options, value) =>
+        value === 'all' ? '' : options.find((o) => o.value === value)?.label;
+
+    return (
+        <div className="flex flex-wrap items-center gap-2">
+            <FilterChip
+                icon={FolderOpen}
+                label="Topic"
+                summary={topicSummary}
+                active={filters.types.length > 0}
+                disabled={locked}
+            >
+                <MultiPanel
+                    options={topicOptions}
+                    value={filters.types}
+                    onChange={(types) => set({types})}
+                    emptyLabel="No topics available."
+                />
+            </FilterChip>
+
+            <FilterChip
+                icon={BarChart3}
+                label="Level"
+                summary={levelSummary}
+                active={filters.levels.length > 0}
+                disabled={locked}
+            >
+                <MultiPanel
+                    options={LEVEL_OPTIONS}
+                    value={filters.levels}
+                    onChange={(levels) => set({levels})}
+                    emptyLabel=""
+                />
+            </FilterChip>
+
+            <FilterChip
+                icon={Bookmark}
+                label="Saved"
+                summary={singleSummary(SAVED_OPTIONS, filters.saved)}
+                active={filters.saved !== 'all'}
+                disabled={locked}
+            >
+                <SinglePanel options={SAVED_OPTIONS} value={filters.saved} onChange={(saved) => set({saved})}/>
+            </FilterChip>
+
+            <FilterChip
+                icon={CircleDot}
+                label="Completed"
+                summary={singleSummary(ATTEMPTED_OPTIONS, filters.attempted)}
+                active={filters.attempted !== 'all'}
+                disabled={locked}
+            >
+                <SinglePanel options={ATTEMPTED_OPTIONS} value={filters.attempted} onChange={(attempted) => set({attempted})}/>
+            </FilterChip>
+
+            <FilterChip
+                icon={Target}
+                label="Result"
+                summary={singleSummary(RESULT_OPTIONS, filters.result)}
+                active={filters.result !== 'all'}
+                disabled={locked}
+            >
+                <SinglePanel options={RESULT_OPTIONS} value={filters.result} onChange={(result) => set({result})}/>
+            </FilterChip>
+
+            {locked ? (
+                <span className="inline-flex items-center gap-1 rounded-lg bg-amber-50 px-2.5 py-1.5 text-xs font-bold text-amber-700">
+                    <Lock className="size-3.5"/> Premium
+                </span>
+            ) : filtersActiveCount(filters) > 0 && (
+                <button
+                    type="button"
+                    onClick={() => onChange(EMPTY_FILTERS)}
+                    className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-2 text-sm font-semibold text-slate-500 hover:bg-slate-100 hover:text-slate-700"
+                >
+                    <RotateCcw className="size-4"/> Reset
+                </button>
+            )}
+        </div>
+    );
+}

--- a/src/pages/trainer/InfiniteQuestionPage.jsx
+++ b/src/pages/trainer/InfiniteQuestionPage.jsx
@@ -6,46 +6,11 @@ import {useNavCollapse} from '../../layout/AppLayout';
 import Question from '../../components/Question';
 import withAuth from '../../hoc/withAuth';
 import api from '../../components/api';
-import {Alert, Button, Card, PageContainer, Select, Spinner} from '../../components/ui';
+import {Alert, Button, Card, PageContainer, Spinner} from '../../components/ui';
 import {billingErrorMessage, startPremiumCheckout} from '../../utils/billing';
 import ResetCountdown from '../../components/ResetCountdown';
 import DiscordCTA from '../../components/Discord';
-
-function TopicControl({quota, topics, selectedTopic, onChange, compact = false}) {
-    const isPremium = quota?.is_premium;
-
-    return (
-        <div className="flex flex-col gap-1.5">
-            <div className="flex items-center justify-between gap-3">
-                <span className="text-xs font-bold uppercase text-slate-400">Topic</span>
-                {!isPremium && (
-                    <span className="inline-flex items-center gap-1 text-xs font-bold text-amber-700">
-                        <Lock className="size-3"/> Premium
-                    </span>
-                )}
-            </div>
-            {isPremium ? (
-                <Select value={selectedTopic} onChange={(e) => onChange(e.target.value)}>
-                    <option value="any">All topics (random)</option>
-                    {topics.map((t) => (
-                        <option key={t} value={t}>{t}</option>
-                    ))}
-                </Select>
-            ) : (
-                <button
-                    type="button"
-                    disabled
-                    className={[
-                        'w-full rounded-xl border-2 border-dashed border-slate-200 bg-white text-left font-semibold text-slate-500',
-                        compact ? 'px-3 py-2 text-sm' : 'px-4 py-2.5 text-[15px]',
-                    ].join(' ')}
-                >
-                    All topics (random)
-                </button>
-            )}
-        </div>
-    );
-}
+import PracticeFilterBar, {EMPTY_FILTERS, filtersActiveCount, filtersToParams} from '../../components/practice/PracticeFilterBar';
 
 function PracticeProgress({subject, stats}) {
     const label = subject === 'math' ? 'Math' : 'English';
@@ -230,7 +195,7 @@ function readPracticeStats(data = {}) {
     };
 }
 
-function AnswerFeedback({status, ratingFeedback, elo, subject, onSubjectChange, quota, topics, selectedTopic, onTopicChange, onNext, loadingQuestions}) {
+function AnswerFeedback({status, ratingFeedback, elo, subject, onSubjectChange, quota, onNext, loadingQuestions}) {
     const answered = status === 'Correct' || status === 'Incorrect';
     const correct = status === 'Correct';
     const Icon = correct ? CheckCircle2 : XCircle;
@@ -249,16 +214,6 @@ function AnswerFeedback({status, ratingFeedback, elo, subject, onSubjectChange, 
             </div>
 
             <RatingChange feedback={ratingFeedback}/>
-
-            <div className="my-4 h-px bg-slate-100"/>
-
-            <TopicControl
-                quota={quota}
-                topics={topics}
-                selectedTopic={selectedTopic}
-                onChange={onTopicChange}
-                compact
-            />
 
             {answered && (
                 <>
@@ -284,39 +239,51 @@ function AnswerFeedback({status, ratingFeedback, elo, subject, onSubjectChange, 
     );
 }
 
-function PracticeEmptyState({emptyState, subject, onSubjectChange, quota, topics, selectedTopic, onTopicChange}) {
-    const completed = emptyState?.error === 'completed_topic';
-    const subjectLabel = subject === 'math' ? 'Math' : 'English';
-    const topicLabel = selectedTopic === 'any' ? `${subjectLabel} practice` : selectedTopic;
+function PracticeEmptyState({emptyState, subject, onSubjectChange, quota, topics, filters, onFiltersChange}) {
+    const error = emptyState?.error;
+    const filtered = filtersActiveCount(filters) > 0;
+    const heading = error === 'completed_topic'
+        ? 'You answered every matching question'
+        : error === 'no_matches'
+            ? 'No questions match these filters'
+            : 'No questions here yet';
+    const body = error === 'completed_topic'
+        ? "You've answered every problem in this slice. Widen your filters to keep going."
+        : error === 'no_matches'
+            ? 'Nothing matches this combination yet. Try loosening a filter or two.'
+            : "We're still building this question set. Check back soon or adjust your filters.";
 
     return (
         <div className="sat-bubble-field min-h-[calc(100vh-4rem)] py-12 sm:py-16">
             <PageContainer className="max-w-2xl">
                 <Card className="sat-arena-card p-6 sm:p-8">
                     <SubjectSwitch subject={subject} onChange={onSubjectChange}/>
-                    <TopicControl
-                        quota={quota}
-                        topics={topics}
-                        selectedTopic={selectedTopic}
-                        onChange={onTopicChange}
-                    />
+                    <div className="mt-4">
+                        <PracticeFilterBar
+                            filters={filters}
+                            onChange={onFiltersChange}
+                            topics={topics}
+                            isPremium={quota?.is_premium}
+                        />
+                    </div>
                     <div className="mt-8 border-t border-slate-100 pt-7 text-center">
-                        <div className={`mx-auto flex size-14 items-center justify-center rounded-2xl ${completed ? 'bg-emerald-50' : 'bg-amber-50'}`}>
-                            {completed
+                        <div className={`mx-auto flex size-14 items-center justify-center rounded-2xl ${error === 'completed_topic' ? 'bg-emerald-50' : 'bg-amber-50'}`}>
+                            {error === 'completed_topic'
                                 ? <CheckCircle2 className="size-7 text-emerald-600"/>
                                 : <Zap className="size-7 text-amber-600"/>}
                         </div>
-                        <h1 className="m-0 mt-4 font-display text-2xl font-bold text-slate-900">
-                            {completed ? `You finished ${topicLabel}` : `No ${topicLabel} questions yet`}
-                        </h1>
-                        <p className="mx-auto mt-3 max-w-md text-slate-600">
-                            {completed
-                                ? "You've answered every problem here. We'll add more soon."
-                                : "We're still building this question set. Check back soon or choose another topic."}
-                        </p>
-                        <Button to="/practice-history" variant="secondary" className="mt-6">
-                            <History className="size-4"/> View practice history
-                        </Button>
+                        <h1 className="m-0 mt-4 font-display text-2xl font-bold text-slate-900">{heading}</h1>
+                        <p className="mx-auto mt-3 max-w-md text-slate-600">{body}</p>
+                        <div className="mt-6 flex flex-wrap justify-center gap-3">
+                            {filtered && (
+                                <Button variant="secondary" onClick={() => onFiltersChange(EMPTY_FILTERS)}>
+                                    Reset filters
+                                </Button>
+                            )}
+                            <Button to="/practice-history" variant="secondary">
+                                <History className="size-4"/> View practice history
+                            </Button>
+                        </div>
                     </div>
                 </Card>
             </PageContainer>
@@ -372,6 +339,20 @@ export function ReadyToPractice({quota, onStart}) {
 // restoring the previous elapsed time.
 const EMPTY_TIMER = {seconds: 0, running: false, startedAt: null, questionId: null};
 
+// Filter selections survive a refresh (unlike the timer) so returning to
+// practice resumes the same slice of questions. Kept per subject since the
+// topic list differs between English and Math.
+const FILTERS_STORAGE_KEY = 'satduel:practice-filters';
+
+function readStoredFilters() {
+    try {
+        const saved = JSON.parse(localStorage.getItem(FILTERS_STORAGE_KEY));
+        return {english: {...EMPTY_FILTERS, ...saved?.english}, math: {...EMPTY_FILTERS, ...saved?.math}};
+    } catch {
+        return {english: {...EMPTY_FILTERS}, math: {...EMPTY_FILTERS}};
+    }
+}
+
 function InfiniteQuestionsPage() {
     const {hidden: navHidden, toggle: toggleNav} = useNavCollapse();
     const [currentQuestion, setCurrentQuestion] = useState(null);
@@ -383,7 +364,7 @@ function InfiniteQuestionsPage() {
         new URLSearchParams(window.location.search).get('subject') === 'math' ? 'math' : 'english');
     const [elos, setElos] = useState({english: null, math: null});
     const [topicsBySubject, setTopicsBySubject] = useState({english: [], math: []});
-    const [selectedTopic, setSelectedTopic] = useState('any');
+    const [filtersBySubject, setFiltersBySubject] = useState(readStoredFilters);
     const [limitReached, setLimitReached] = useState(false);
     const [billingLoading, setBillingLoading] = useState(false);
     const [ratingFeedback, setRatingFeedback] = useState(null);
@@ -395,6 +376,15 @@ function InfiniteQuestionsPage() {
     const [manualTimer, setManualTimer] = useState(EMPTY_TIMER);
     const {loading} = useAuth();
     const hasFetchedData = useRef(false);
+    const filters = filtersBySubject[subject];
+
+    useEffect(() => {
+        try {
+            localStorage.setItem(FILTERS_STORAGE_KEY, JSON.stringify(filtersBySubject));
+        } catch {
+            // Filters still work when browser storage is unavailable.
+        }
+    }, [filtersBySubject]);
 
     useEffect(() => {
         if (!manualTimer.running) return undefined;
@@ -423,15 +413,15 @@ function InfiniteQuestionsPage() {
         ));
     }, [currentQuestion?.id]);
 
-    const fetchNextQuestion = useCallback(async (topic, subj) => {
+    const fetchNextQuestion = useCallback(async (filtersArg, subj) => {
+        const effectiveSubject = typeof subj === 'string' ? subj : subject;
+        const effectiveFilters = filtersArg || filtersBySubject[effectiveSubject] || EMPTY_FILTERS;
         try {
             setLoadingQuestions(true);
             setError(null);
-            const effectiveSubject = typeof subj === 'string' ? subj : subject;
-            const params = {subject: effectiveSubject};
-            const effectiveTopic = typeof topic === 'string' ? topic : selectedTopic;
-            if (effectiveTopic && effectiveTopic !== 'any') params.type = effectiveTopic;
-            const response = await api.get('api/practice/next/', {params});
+            const response = await api.get('api/practice/next/', {
+                params: filtersToParams(effectiveFilters, effectiveSubject),
+            });
             setCurrentQuestion(response.data.question || null);
             setQuota(response.data.quota || null);
             setQuestionStatus('Blank');
@@ -443,14 +433,16 @@ function InfiniteQuestionsPage() {
                 setQuota(data.quota || null);
                 setLimitReached(true);
             } else if (data?.error === 'premium_required') {
-                setSelectedTopic('any');
-                const response = await api.get('api/practice/next/', {params: {subject: subj || subject}});
+                // The filter bar is locked for free users, so this only fires as
+                // a safety net: drop the filters and serve a plain question.
+                setFiltersBySubject((prev) => ({...prev, [effectiveSubject]: {...EMPTY_FILTERS}}));
+                const response = await api.get('api/practice/next/', {params: {subject: effectiveSubject}});
                 setCurrentQuestion(response.data.question || null);
                 setQuota(response.data.quota || null);
                 setQuestionStatus('Blank');
                 setRatingFeedback(null);
                 setEmptyState(null);
-            } else if (data?.error === 'completed_topic' || data?.error === 'no_questions') {
+            } else if (['completed_topic', 'no_questions', 'no_matches'].includes(data?.error)) {
                 setCurrentQuestion(null);
                 setQuota(data.quota || null);
                 setEmptyState(data);
@@ -460,7 +452,7 @@ function InfiniteQuestionsPage() {
         } finally {
             setLoadingQuestions(false);
         }
-    }, [selectedTopic, subject]);
+    }, [subject, filtersBySubject]);
 
     const fetchPracticeStatus = useCallback(async () => {
         try {
@@ -512,16 +504,16 @@ function InfiniteQuestionsPage() {
             : timer));
     };
 
-    const handleTopicChange = (topic) => {
-        setSelectedTopic(topic);
-        fetchNextQuestion(topic);
+    const handleFiltersChange = (nextFilters) => {
+        setFiltersBySubject((prev) => ({...prev, [subject]: nextFilters}));
+        fetchNextQuestion(nextFilters);
     };
 
     const handleSubjectChange = (subj) => {
         if (subj === subject) return;
         setSubject(subj);
-        setSelectedTopic('any');  // topic lists differ per subject
-        fetchNextQuestion('any', subj);
+        // Each subject keeps its own filters (the topic lists differ).
+        fetchNextQuestion(filtersBySubject[subj], subj);
     };
 
     const handleQuestionSubmit = async (id, choice) => {
@@ -667,8 +659,8 @@ function InfiniteQuestionsPage() {
                 onSubjectChange={handleSubjectChange}
                 quota={quota}
                 topics={topicsBySubject[subject] || []}
-                selectedTopic={selectedTopic}
-                onTopicChange={handleTopicChange}
+                filters={filters}
+                onFiltersChange={handleFiltersChange}
             />
         );
     }
@@ -707,6 +699,15 @@ function InfiniteQuestionsPage() {
                     </div>
                 </div>
 
+                <div className="mb-5">
+                    <PracticeFilterBar
+                        filters={filters}
+                        onChange={handleFiltersChange}
+                        topics={topicsBySubject[subject] || []}
+                        isPremium={quota?.is_premium}
+                    />
+                </div>
+
                 <div className="mb-5 lg:hidden">
                     <AnswerFeedback
                         status={questionStatus}
@@ -715,9 +716,6 @@ function InfiniteQuestionsPage() {
                         subject={subject}
                         onSubjectChange={handleSubjectChange}
                         quota={quota}
-                        topics={topicsBySubject[subject] || []}
-                        selectedTopic={selectedTopic}
-                        onTopicChange={handleTopicChange}
                         onNext={() => quota?.remaining === 0 ? setLimitReached(true) : fetchNextQuestion()}
                         loadingQuestions={loadingQuestions}
                     />
@@ -749,9 +747,6 @@ function InfiniteQuestionsPage() {
                                 subject={subject}
                                 onSubjectChange={handleSubjectChange}
                                 quota={quota}
-                                topics={topicsBySubject[subject] || []}
-                                selectedTopic={selectedTopic}
-                                onTopicChange={handleTopicChange}
                                 onNext={() => quota?.remaining === 0 ? setLimitReached(true) : fetchNextQuestion()}
                                 loadingQuestions={loadingQuestions}
                             />


### PR DESCRIPTION
Replace the sidebar topic dropdown with a filter chip bar at the top of the practice page: Topic and Level are multi-select popovers; Saved, Completed, and Result are single-select. The bar is premium-gated — locked with a Premium pill for free users.

Filter selections persist per subject in localStorage so a refresh resumes the same slice. A premium_required response (safety net) silently clears the filters and serves a plain question. The empty state now offers to widen or reset filters.