### PR TITLE
Restyle party pages to the app's light theme

### DIFF
--- a/src/pages/party/PartyHomePage.jsx
+++ b/src/pages/party/PartyHomePage.jsx
@@ -147,8 +147,8 @@ function PartyHomePage() {
     return (
         <PageContainer maxWidth="max-w-2xl" className="px-4 py-8 sm:py-12">
             <div className="text-center">
-                <div className="mx-auto mb-4 grid size-16 place-items-center rounded-3xl bg-gradient-to-br from-primary-500 to-fuchsia-500 shadow-lg shadow-primary-500/30">
-                    <PartyPopper className="size-8 text-white"/>
+                <div className="mx-auto mb-4 grid size-16 place-items-center rounded-3xl bg-primary-50">
+                    <PartyPopper className="size-8 text-primary-600"/>
                 </div>
                 <h1 className="font-display text-3xl font-bold text-slate-900 sm:text-4xl">Party Mode</h1>
                 <p className="mx-auto mt-2 max-w-md text-[15px] leading-relaxed text-slate-500">
@@ -162,13 +162,13 @@ function PartyHomePage() {
                         <button
                             type="button"
                             onClick={() => setView('create')}
-                            className="group cursor-pointer rounded-3xl bg-gradient-to-br from-primary-500 to-fuchsia-500 p-6 text-left shadow-lg shadow-primary-500/25 transition-transform active:scale-[0.98] sm:p-7"
+                            className="group cursor-pointer rounded-3xl border-2 border-primary-200 bg-primary-50/60 p-6 text-left shadow-sm transition-all hover:border-primary-300 active:scale-[0.98] sm:p-7"
                         >
-                            <span className="grid size-12 place-items-center rounded-2xl bg-white/20">
-                                <PartyPopper className="size-6 text-white"/>
+                            <span className="grid size-12 place-items-center rounded-2xl bg-primary-100">
+                                <PartyPopper className="size-6 text-primary-600"/>
                             </span>
-                            <span className="mt-4 block text-xl font-bold text-white">Create a room</span>
-                            <span className="mt-1 block text-sm leading-relaxed text-white/80">
+                            <span className="mt-4 block text-xl font-bold text-slate-900">Create a room</span>
+                            <span className="mt-1 block text-sm leading-relaxed text-slate-500">
                                 Host the game and get a join code to share.
                             </span>
                         </button>

--- a/src/pages/party/PartyRoomPage.jsx
+++ b/src/pages/party/PartyRoomPage.jsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {useNavigate, useParams} from 'react-router-dom';
-import {Check, Circle, Copy, Crown, Diamond, Square, Triangle, Users, X} from 'lucide-react';
+import {Check, Copy, Crown, Users, X} from 'lucide-react';
 import {Button, Spinner} from '../../components/ui';
 import UserAvatar from '../../components/UserAvatar';
 import RenderWithMath from '../../components/RenderWithMath';
@@ -10,26 +10,19 @@ import '../../styles/party.css';
 
 const POLL_MS = 1000;
 const CHOICE_LABELS = ['A', 'B', 'C', 'D'];
-// Kahoot-style color/shape pairs so answers are tellable at a glance.
-const CHOICE_STYLES = [
-    {bg: 'bg-[#E21B3C] hover:bg-[#c91734]', Icon: Triangle},
-    {bg: 'bg-[#1368CE] hover:bg-[#105ab2]', Icon: Diamond},
-    {bg: 'bg-[#B8860B] hover:bg-[#9e7409]', Icon: Circle},
-    {bg: 'bg-[#26890C] hover:bg-[#20740a]', Icon: Square},
-];
 const MEDALS = ['🥇', '🥈', '🥉'];
 
 const fmtClock = (s) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, '0')}`;
 
 function WaitingDots({children}) {
     return (
-        <p className="m-0 animate-pulse text-center text-[15px] font-semibold text-white/80">{children}</p>
+        <p className="m-0 animate-pulse text-center text-[15px] font-semibold text-slate-500">{children}</p>
     );
 }
 
 function PlayerChip({player}) {
     return (
-        <div className="party-fade-up flex items-center gap-2 rounded-full bg-white/15 py-1.5 pl-1.5 pr-4 backdrop-blur">
+        <div className="party-fade-up flex items-center gap-2 rounded-full border border-slate-200 bg-white py-1.5 pl-1.5 pr-4 shadow-sm">
             <UserAvatar
                 backgroundId={player.avatar}
                 iconId={player.avatar_icon}
@@ -37,7 +30,7 @@ function PlayerChip({player}) {
                 size="xs"
                 className="ring-0"
             />
-            <span className="max-w-32 truncate text-sm font-bold text-white">{player.username}</span>
+            <span className="max-w-32 truncate text-sm font-bold text-slate-800">{player.username}</span>
         </div>
     );
 }
@@ -68,34 +61,34 @@ function Lobby({state, roomId, onLeave}) {
     return (
         <div className="mx-auto flex min-h-dvh w-full max-w-xl flex-col px-5 py-6">
             <div className="flex items-center justify-between">
-                <span className="inline-flex items-center gap-1.5 rounded-full bg-white/15 px-3 py-1.5 text-sm font-bold text-white">
-                    <Users className="size-4"/> {state.players.length}/{settings.max_players}
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-bold text-slate-700">
+                    <Users className="size-4 text-slate-400"/> {state.players.length}/{settings.max_players}
                 </span>
                 <button
                     type="button"
                     onClick={onLeave}
                     aria-label="Leave room"
-                    className="grid size-9 cursor-pointer place-items-center rounded-full bg-white/15 text-white hover:bg-white/25"
+                    className="grid size-9 cursor-pointer place-items-center rounded-full border border-slate-200 bg-white text-slate-500 hover:text-slate-800"
                 >
                     <X className="size-5"/>
                 </button>
             </div>
 
             <div className="mt-8 text-center">
-                <p className="m-0 text-sm font-bold uppercase tracking-[0.2em] text-white/70">Join code</p>
+                <p className="m-0 text-sm font-bold uppercase tracking-[0.2em] text-slate-400">Join code</p>
                 <button
                     type="button"
                     onClick={copyCode}
                     title="Copy the join code"
-                    className="mt-2 inline-flex cursor-pointer items-center gap-3 rounded-3xl bg-white px-7 py-4 shadow-xl transition-transform active:scale-95"
+                    className="mt-2 inline-flex cursor-pointer items-center gap-3 rounded-3xl border border-slate-200 bg-white px-7 py-4 shadow-sm transition-transform active:scale-95"
                 >
                     <span className="font-mono text-4xl font-black tracking-[0.25em] text-slate-900 sm:text-5xl">
                         {state.code}
                     </span>
                     <Copy className="size-5 text-slate-400"/>
                 </button>
-                <p className="mt-3 text-sm text-white/70">
-                    Friends open <span className="font-bold text-white">Party → Join room</span> and type this in.
+                <p className="mt-3 text-sm text-slate-500">
+                    Friends open <span className="font-bold text-slate-700">Party → Join room</span> and type this in.
                 </p>
             </div>
 
@@ -104,7 +97,7 @@ function Lobby({state, roomId, onLeave}) {
             </div>
 
             <div className="mt-auto pt-8">
-                <div className="mb-4 flex flex-wrap justify-center gap-x-4 gap-y-1 text-[13px] font-semibold text-white/70">
+                <div className="mb-4 flex flex-wrap justify-center gap-x-4 gap-y-1 text-[13px] font-semibold text-slate-400">
                     <span className="capitalize">{settings.subject === 'mixed' ? 'Math + English' : settings.subject}</span>
                     <span>·</span>
                     <span className="capitalize">{settings.difficulty}</span>
@@ -115,10 +108,10 @@ function Lobby({state, roomId, onLeave}) {
                 </div>
                 {state.is_host ? (
                     <>
-                        <Button block size="lg" loading={starting} onClick={start} className="!border-white !bg-white !text-primary-700 hover:!bg-primary-50">
+                        <Button block size="lg" loading={starting} onClick={start}>
                             Start game
                         </Button>
-                        <p className="mb-0 mt-2 text-center text-xs text-white/60">Players can still join until you start.</p>
+                        <p className="mb-0 mt-2 text-center text-xs text-slate-400">Players can still join until you start.</p>
                     </>
                 ) : (
                     <WaitingDots>Waiting for {state.host_username} to start…</WaitingDots>
@@ -133,8 +126,8 @@ function Countdown({secondsLeft}) {
     return (
         <div className="grid min-h-dvh place-items-center">
             <div key={digit} className="party-pop text-center">
-                <p className="m-0 text-[9rem] font-black leading-none text-white drop-shadow-lg">{digit}</p>
-                <p className="m-0 mt-2 text-lg font-bold uppercase tracking-[0.3em] text-white/70">Get ready</p>
+                <p className="m-0 text-[9rem] font-black leading-none text-primary-600">{digit}</p>
+                <p className="m-0 mt-2 text-lg font-bold uppercase tracking-[0.3em] text-slate-400">Get ready</p>
             </div>
         </div>
     );
@@ -154,7 +147,7 @@ function QuestionPhase({state, roomId, secondsLeft}) {
     const totalSeconds = state.settings.seconds_per_question;
     const fraction = Math.max(0, Math.min(1, secondsLeft / totalSeconds));
     const urgent = secondsLeft <= 10;
-    // SAT choices can be full sentences; a Kahoot 2x2 grid only works for short ones.
+    // Short answers (math) sit two-up; sentence answers (English) stack.
     const compactChoices = question.choices.every((choice) => String(choice).length <= 32);
 
     const answer = async (letter) => {
@@ -174,31 +167,30 @@ function QuestionPhase({state, roomId, secondsLeft}) {
     return (
         <div className="mx-auto flex min-h-dvh w-full max-w-3xl flex-col px-4 py-4 sm:py-6">
             <div className="flex items-center justify-between gap-3">
-                <span className="rounded-full bg-white/15 px-3.5 py-1.5 text-sm font-bold text-white">
+                <span className="rounded-full border border-slate-200 bg-white px-3.5 py-1.5 text-sm font-bold text-slate-700">
                     Q {state.question_number}/{state.total_questions}
                 </span>
-                <span className="text-xs font-semibold text-white/70">
+                <span className="text-xs font-semibold text-slate-400">
                     {answeredCount}/{state.players.length} answered
                 </span>
                 <span
                     className={`rounded-full px-3.5 py-1.5 font-mono text-sm font-bold ${
-                        urgent ? 'animate-pulse bg-rose-500 text-white' : 'bg-white/15 text-white'
+                        urgent
+                            ? 'animate-pulse bg-rose-500 text-white'
+                            : 'border border-slate-200 bg-white text-slate-700'
                     }`}
                 >
                     {fmtClock(secondsLeft)}
                 </span>
             </div>
-            <div className="mt-2.5 h-1.5 overflow-hidden rounded-full bg-white/15">
+            <div className="mt-2.5 h-1.5 overflow-hidden rounded-full bg-slate-200">
                 <div
-                    className={`h-full rounded-full ${urgent ? 'bg-rose-400' : 'bg-white'}`}
+                    className={`h-full rounded-full ${urgent ? 'bg-rose-400' : 'bg-primary-500'}`}
                     style={{width: `${fraction * 100}%`, transition: 'width 1s linear'}}
                 />
             </div>
 
-            <div className="mt-4 min-h-0 flex-1 overflow-y-auto rounded-2xl bg-white p-4 shadow-xl sm:p-6">
-                <p className="m-0 mb-2 text-[11px] font-bold uppercase tracking-[0.12em] text-primary-600">
-                    {question.question_type} · Level {question.difficulty}
-                </p>
+            <div className="mt-4 min-h-0 flex-1 overflow-y-auto rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
                 <div className="text-[15.5px] leading-relaxed text-slate-900 sm:text-[17px]">
                     <RenderWithMath text={question.question}/>
                 </div>
@@ -207,7 +199,6 @@ function QuestionPhase({state, roomId, secondsLeft}) {
             <div className={`mt-4 grid gap-2.5 ${compactChoices ? 'grid-cols-2' : 'grid-cols-1'} sm:gap-3`}>
                 {question.choices.map((choice, index) => {
                     const letter = CHOICE_LABELS[index];
-                    const {bg, Icon} = CHOICE_STYLES[index];
                     const isMine = locked === letter;
                     const dim = locked && !isMine;
                     return (
@@ -216,22 +207,32 @@ function QuestionPhase({state, roomId, secondsLeft}) {
                             type="button"
                             onClick={() => answer(letter)}
                             disabled={Boolean(locked)}
-                            className={`flex min-h-14 cursor-pointer items-center gap-3 rounded-2xl px-4 py-3 text-left shadow-lg transition-all active:scale-[0.98] disabled:cursor-default sm:min-h-16 ${bg} ${
-                                dim ? 'opacity-35' : ''
-                            } ${isMine ? 'ring-4 ring-white' : ''}`}
+                            className={`flex min-h-14 cursor-pointer items-center gap-3 rounded-2xl border-2 px-4 py-3 text-left transition-all active:scale-[0.98] disabled:cursor-default sm:min-h-16 ${
+                                isMine
+                                    ? 'border-primary-400 bg-primary-50'
+                                    : 'border-slate-200 bg-white hover:border-primary-300'
+                            } ${dim ? 'opacity-40' : ''}`}
                         >
-                            <Icon className="size-5 shrink-0 fill-current text-white"/>
-                            <span className="min-w-0 flex-1 text-[15px] font-semibold leading-snug text-white">
+                            <span
+                                className={`grid size-7 shrink-0 place-items-center rounded-full text-[13px] font-bold ${
+                                    isMine
+                                        ? 'bg-primary-600 text-white'
+                                        : 'border-2 border-slate-300 text-slate-500'
+                                }`}
+                            >
+                                {letter}
+                            </span>
+                            <span className="min-w-0 flex-1 text-[15px] font-semibold leading-snug text-slate-900">
                                 <RenderWithMath text={choice}/>
                             </span>
-                            {isMine && <Check className="size-5 shrink-0 text-white"/>}
+                            {isMine && <Check className="size-5 shrink-0 text-primary-600"/>}
                         </button>
                     );
                 })}
             </div>
 
             {locked && (
-                <p className="m-0 mt-3 animate-pulse text-center text-sm font-bold text-white/85">
+                <p className="m-0 mt-3 animate-pulse text-center text-sm font-bold text-slate-500">
                     Locked in! Waiting for everyone else…
                 </p>
             )}
@@ -256,20 +257,22 @@ function Leaderboard({state, roomId}) {
 
     return (
         <div className="mx-auto flex min-h-dvh w-full max-w-xl flex-col px-5 py-6">
-            <p className="m-0 text-center text-sm font-bold uppercase tracking-[0.2em] text-white/70">
+            <p className="m-0 text-center text-sm font-bold uppercase tracking-[0.2em] text-slate-400">
                 Question {state.question_number}/{state.total_questions}
             </p>
 
             <div
-                className={`party-fade-up mt-4 rounded-2xl p-4 text-center shadow-xl ${
-                    reveal.correct ? 'bg-emerald-500' : 'bg-rose-500'
+                className={`party-fade-up mt-4 rounded-2xl border p-4 text-center ${
+                    reveal.correct
+                        ? 'border-emerald-200 bg-emerald-50'
+                        : 'border-rose-200 bg-rose-50'
                 }`}
             >
-                <p className="m-0 text-xl font-black text-white">
+                <p className={`m-0 text-xl font-black ${reveal.correct ? 'text-emerald-700' : 'text-rose-700'}`}>
                     {reveal.correct ? `Correct! +${reveal.points_earned}` : reveal.your_choice ? 'Not this time' : "Time's up"}
                 </p>
                 {!reveal.correct && (
-                    <div className="mt-1 text-sm font-semibold text-white/90">
+                    <div className="mt-1 text-sm font-semibold text-rose-600">
                         Answer: {reveal.correct_choice} — <span className="inline-block max-w-full align-bottom"><RenderWithMath text={reveal.correct_text || ''}/></span>
                     </div>
                 )}
@@ -279,7 +282,7 @@ function Leaderboard({state, roomId}) {
                 {state.players.map((player, index) => (
                     <div
                         key={player.id}
-                        className="party-fade-up flex items-center gap-3 rounded-2xl bg-white/95 px-3.5 py-2.5 shadow"
+                        className="party-fade-up flex items-center gap-3 rounded-2xl border border-slate-200 bg-white px-3.5 py-2.5 shadow-sm"
                         style={{animationDelay: `${index * 70}ms`}}
                     >
                         <span className="w-7 text-center text-lg">{MEDALS[index] || <span className="text-sm font-bold text-slate-400">{index + 1}</span>}</span>
@@ -301,7 +304,7 @@ function Leaderboard({state, roomId}) {
 
             <div className="pt-5">
                 {state.is_host ? (
-                    <Button block size="lg" loading={advancing} onClick={next} className="!border-white !bg-white !text-primary-700 hover:!bg-primary-50">
+                    <Button block size="lg" loading={advancing} onClick={next}>
                         {reveal.is_last ? 'Show podium 🏆' : 'Next question →'}
                     </Button>
                 ) : (
@@ -316,29 +319,29 @@ function Podium({state, onExit}) {
     const [top1, top2, top3] = state.players;
     const rest = state.players.slice(3);
     const columns = [
-        {player: top2, place: 2, height: 'h-28', delay: '0.35s', tone: 'bg-white/80'},
-        {player: top1, place: 1, height: 'h-40', delay: '0.75s', tone: 'bg-amber-300'},
-        {player: top3, place: 3, height: 'h-20', delay: '0s', tone: 'bg-white/60'},
+        {player: top2, place: 2, height: 'h-28', delay: '0.35s', tone: 'bg-slate-200'},
+        {player: top1, place: 1, height: 'h-40', delay: '0.75s', tone: 'bg-amber-200'},
+        {player: top3, place: 3, height: 'h-20', delay: '0s', tone: 'bg-orange-100'},
     ];
 
     return (
         <div className="mx-auto flex min-h-dvh w-full max-w-xl flex-col px-5 py-8">
-            <h1 className="m-0 text-center font-display text-3xl font-black text-white">Final results</h1>
+            <h1 className="m-0 text-center font-display text-3xl font-black text-slate-900">Final results</h1>
 
             <div className="mt-10 flex items-end justify-center gap-3">
                 {columns.map(({player, place, height, delay, tone}) => player ? (
                     <div key={place} className="flex w-1/3 max-w-36 flex-col items-center">
                         <div className={`mb-2 text-center ${place === 1 ? 'party-bounce' : ''}`}>
-                            {place === 1 && <Crown className="mx-auto mb-1 size-7 fill-amber-300 text-amber-300"/>}
+                            {place === 1 && <Crown className="mx-auto mb-1 size-7 fill-amber-400 text-amber-400"/>}
                             <UserAvatar
                                 backgroundId={player.avatar}
                                 iconId={player.avatar_icon}
                                 profile={{username: player.username}}
                                 size="sm"
-                                className="mx-auto ring-2 ring-white"
+                                className="mx-auto ring-2 ring-slate-200"
                             />
-                            <p className="m-0 mt-1 max-w-32 truncate text-sm font-bold text-white">{player.username}</p>
-                            <p className="m-0 font-mono text-lg font-black text-white">{player.score}</p>
+                            <p className="m-0 mt-1 max-w-32 truncate text-sm font-bold text-slate-800">{player.username}</p>
+                            <p className="m-0 font-mono text-lg font-black text-slate-900">{player.score}</p>
                         </div>
                         <div
                             className={`party-podium-bar w-full rounded-t-2xl ${height} ${tone} grid place-items-start justify-center pt-2 text-2xl`}
@@ -353,8 +356,8 @@ function Podium({state, onExit}) {
             {rest.length > 0 && (
                 <div className="mt-8 space-y-2">
                     {rest.map((player, index) => (
-                        <div key={player.id} className="flex items-center gap-3 rounded-2xl bg-white/10 px-3.5 py-2 text-white">
-                            <span className="w-6 text-center text-sm font-bold text-white/60">{index + 4}</span>
+                        <div key={player.id} className="flex items-center gap-3 rounded-2xl border border-slate-200 bg-white px-3.5 py-2 text-slate-800">
+                            <span className="w-6 text-center text-sm font-bold text-slate-400">{index + 4}</span>
                             <span className="min-w-0 flex-1 truncate text-[15px] font-semibold">{player.username}</span>
                             <span className="font-mono font-bold">{player.score}</span>
                         </div>
@@ -363,7 +366,7 @@ function Podium({state, onExit}) {
             )}
 
             <div className="mt-auto pt-8">
-                <Button block size="lg" onClick={onExit} className="!border-white !bg-white !text-primary-700 hover:!bg-primary-50">
+                <Button block size="lg" onClick={onExit}>
                     Back to Party
                 </Button>
             </div>
@@ -412,18 +415,17 @@ function PartyRoomPage() {
     }, [roomId, navigate]);
 
     const leave = useCallback(async () => {
-        if (state?.is_host && !window.confirm('Leaving closes the room for everyone. Leave?')) return;
         try {
             await api.post(`/api/party/${roomId}/leave/`);
         } catch {
-            // Leaving is best-effort; the lobby prunes idle players anyway.
+            // Leaving is best-effort; presence timeouts clean up after us anyway.
         }
         navigate('/party');
-    }, [state?.is_host, roomId, navigate]);
+    }, [roomId, navigate]);
 
     if (!state) {
         return (
-            <div className="grid min-h-dvh place-items-center bg-gradient-to-b from-primary-600 to-fuchsia-800">
+            <div className="grid min-h-dvh place-items-center bg-slate-50">
                 <Spinner/>
             </div>
         );
@@ -448,8 +450,8 @@ function PartyRoomPage() {
         content = (
             <div className="grid min-h-dvh place-items-center px-6 text-center">
                 <div>
-                    <p className="text-lg font-bold text-white">The host closed this room.</p>
-                    <Button size="lg" onClick={() => navigate('/party')} className="mt-4 !border-white !bg-white !text-primary-700">
+                    <p className="text-lg font-bold text-slate-800">This room has closed.</p>
+                    <Button size="lg" onClick={() => navigate('/party')} className="mt-4">
                         Back to Party
                     </Button>
                 </div>
@@ -458,7 +460,7 @@ function PartyRoomPage() {
     }
 
     return (
-        <div className="min-h-dvh bg-gradient-to-b from-primary-600 via-primary-700 to-fuchsia-800">
+        <div className="min-h-dvh bg-slate-50">
             {content}
         </div>
     );


### PR DESCRIPTION
Drop the purple gradients and Kahoot color/shape answer grid: party pages now use the standard slate/white look with the primary accent. Choices are plain A/B/C/D rows, the question card no longer shows type/level, and leaving is a silent handoff (backend migrates the host) so the leave confirm is gone.