### PR TITLE
Add mode picker, Teams lobby, and Final Jeopardy betting UI

### DIFF
--- a/src/pages/WelcomePage.jsx
+++ b/src/pages/WelcomePage.jsx
@@ -2,7 +2,6 @@ import React, {useEffect} from 'react';
 import {Helmet} from 'react-helmet';
 import {Link, useNavigate} from 'react-router-dom';
 import {ArrowRight, BookOpen, Calculator, Gauge} from 'lucide-react';
-import api from '../components/api';
 import {useAuth} from '../context/AuthContext';
 import useSdTheme from '../hooks/useSdTheme';
 import {consumePostLoginRedirect} from '../utils/authRedirect';
@@ -46,8 +45,9 @@ const WelcomePage = () => {
             navigate(redirectTo, {replace: true});
             return;
         }
-        // Fire-and-forget: this screen only shows once.
-        api.post('api/profile/update_first_login/').then(setFirstLogin).catch(() => {});
+        // This screen only shows once. The server derives is_first_login from
+        // last_login, which login already bumped, so clearing it locally is enough.
+        setFirstLogin();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 

--- a/src/pages/party/PartyHomePage.jsx
+++ b/src/pages/party/PartyHomePage.jsx
@@ -1,10 +1,11 @@
 import React, {useState} from 'react';
 import {useNavigate} from 'react-router-dom';
-import {ArrowLeft, Crown, PartyPopper, Play, Smartphone, Trophy, Users} from 'lucide-react';
-import {Button, PageContainer} from '../../components/ui';
+import {ArrowLeft, Check, Crown, HelpCircle, PartyPopper, Play, Smartphone, Trophy, Users} from 'lucide-react';
+import {Button, ModalShell, PageContainer, Toggle} from '../../components/ui';
 import {useAuth} from '../../context/AuthContext';
 import api from '../../components/api';
 import {notify} from '../../utils/notify';
+import {PARTY_MODES} from './modes';
 
 const SUBJECTS = [
     ['math', 'Math'],
@@ -16,13 +17,18 @@ const DIFFICULTIES = [
     ['medium', 'Medium', 'Levels 2–4'],
     ['hard', 'Hard', 'Levels 3–5'],
 ];
+const TEAM_COUNTS = [
+    ['2', '2 teams'],
+    ['3', '3 teams'],
+    ['4', '4 teams'],
+];
 const TIMER_OPTIONS = [30, 45, 60, 90, 120];
 
-const STEPS = [
+const HOW_IT_WORKS = [
     {
         icon: PartyPopper,
-        title: 'Create a room',
-        text: 'One person hosts: pick the subject, difficulty, number of questions, and how long everyone gets per question.',
+        title: 'Pick a mode and host a room',
+        text: 'One person hosts: choose a game mode, then set the subject, difficulty, number of questions, and how long everyone gets.',
     },
     {
         icon: Smartphone,
@@ -37,7 +43,7 @@ const STEPS = [
     {
         icon: Trophy,
         title: 'Leaderboard and podium',
-        text: 'After each question the standings pop up, and the host advances to the next one. The game ends on the podium with the top three players.',
+        text: 'After each question the standings pop up, with the answer spread and a full review of the question. The game ends on the podium.',
     },
 ];
 
@@ -102,6 +108,125 @@ function StepperInput({label, hint, value, onChange, min, max}) {
     );
 }
 
+function StepBar({step}) {
+    const labels = ['Select mode', 'Room settings'];
+    return (
+        <div className="mb-6 flex items-center gap-2">
+            {labels.map((label, index) => {
+                const number = index + 1;
+                const done = step > number;
+                const active = step === number;
+                return (
+                    <React.Fragment key={label}>
+                        <div className="flex items-center gap-2">
+                            <span
+                                className={`grid size-7 shrink-0 place-items-center rounded-full text-xs font-bold transition-colors ${
+                                    done
+                                        ? 'bg-primary-600 text-white'
+                                        : active
+                                            ? 'bg-primary-100 text-primary-700 ring-2 ring-primary-400'
+                                            : 'bg-slate-100 text-slate-400'
+                                }`}
+                            >
+                                {done ? <Check className="size-4"/> : number}
+                            </span>
+                            <span
+                                className={`text-[13px] font-bold ${
+                                    active ? 'text-slate-900' : 'text-slate-400'
+                                }`}
+                            >
+                                {label}
+                            </span>
+                        </div>
+                        {number < labels.length && (
+                            <span
+                                className={`h-0.5 min-w-4 flex-1 rounded-full ${
+                                    done ? 'bg-primary-500' : 'bg-slate-200'
+                                }`}
+                            />
+                        )}
+                    </React.Fragment>
+                );
+            })}
+        </div>
+    );
+}
+
+function ModeCard({mode, selected, onSelect, onDetails}) {
+    const {Art} = mode;
+    return (
+        <div className="relative">
+            <button
+                type="button"
+                onClick={onSelect}
+                disabled={!mode.available}
+                className={`w-full cursor-pointer overflow-hidden rounded-3xl border-2 p-4 text-left shadow-sm transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60 disabled:active:scale-100 ${
+                    selected ? mode.cardOn : mode.card
+                } ${mode.available ? 'hover:-translate-y-0.5 hover:shadow-md' : ''}`}
+            >
+                <div className={`mx-auto h-20 w-full max-w-44 ${mode.text}`}>
+                    <Art/>
+                </div>
+                <div className="mt-3 flex items-center gap-2">
+                    <span className="text-lg font-bold text-slate-900">{mode.name}</span>
+                    {selected && <Check className={`size-4 ${mode.text}`}/>}
+                    {!mode.available && (
+                        <span className="rounded-full bg-slate-200 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-slate-500">
+                            Soon
+                        </span>
+                    )}
+                </div>
+                <p className="m-0 mt-0.5 pr-6 text-[13px] leading-snug text-slate-500">{mode.tagline}</p>
+            </button>
+            <button
+                type="button"
+                onClick={onDetails}
+                aria-label={`How ${mode.name} works`}
+                title={`How ${mode.name} works`}
+                className="absolute right-3 top-3 grid size-7 cursor-pointer place-items-center rounded-full bg-white/70 text-slate-400 backdrop-blur transition-colors hover:bg-white hover:text-slate-700"
+            >
+                <HelpCircle className="size-4"/>
+            </button>
+        </div>
+    );
+}
+
+function ModeDetailModal({mode, onClose, onPick}) {
+    if (!mode) return null;
+    const {Art} = mode;
+    return (
+        <ModalShell
+            open
+            title={mode.name}
+            onClose={onClose}
+            footer={
+                mode.available ? (
+                    <Button onClick={onPick}>Play {mode.name}</Button>
+                ) : (
+                    <span className="text-sm font-semibold text-slate-400">Coming soon</span>
+                )
+            }
+        >
+            <div className={`mx-auto h-24 w-full max-w-52 ${mode.text}`}>
+                <Art/>
+            </div>
+            <p className="mt-3 text-[15px] font-semibold text-slate-800">{mode.summary}</p>
+            <ul className="mt-3 space-y-2 pl-0">
+                {mode.how.map((line) => (
+                    <li key={line} className="flex gap-2.5 text-sm leading-relaxed text-slate-600">
+                        <span className={`mt-1.5 size-1.5 shrink-0 rounded-full bg-current ${mode.text}`}/>
+                        <span>{line}</span>
+                    </li>
+                ))}
+            </ul>
+            <div className="mt-4 rounded-2xl bg-slate-50 p-3">
+                <p className="m-0 text-[11px] font-bold uppercase tracking-wide text-slate-400">Best for</p>
+                <p className="m-0 mt-1 text-sm leading-relaxed text-slate-600">{mode.bestFor}</p>
+            </div>
+        </ModalShell>
+    );
+}
+
 function PartyHomePage() {
     const {user} = useAuth();
     const navigate = useNavigate();
@@ -110,16 +235,38 @@ function PartyHomePage() {
     const questionCap = premium ? 50 : 20;
 
     const [view, setView] = useState('menu'); // menu | create | join
+    const [step, setStep] = useState(1); // 1 = pick mode, 2 = room settings
+    const [detailMode, setDetailMode] = useState(null);
     const [busy, setBusy] = useState(false);
     const [joinCode, setJoinCode] = useState('');
     const [settings, setSettings] = useState({
+        mode: 'classic',
         max_players: 6,
         num_questions: 10,
         seconds_per_question: 90,
         subject: 'mixed',
         difficulty: 'medium',
+        num_teams: 2,
+        random_teams: true,
     });
     const set = (key) => (value) => setSettings((s) => ({...s, [key]: value}));
+
+    const pickMode = (key) => {
+        setSettings((s) => ({
+            ...s,
+            mode: key,
+            // Teams need one player per team; Jeopardy needs a question before the bet.
+            max_players: key === 'teams' ? Math.max(s.max_players, s.num_teams) : s.max_players,
+            num_questions: key === 'jeopardy' ? Math.max(s.num_questions, 2) : s.num_questions,
+        }));
+        setStep(2);
+        setDetailMode(null);
+    };
+
+    const openCreate = () => {
+        setView('create');
+        setStep(1);
+    };
 
     const createRoom = async () => {
         setBusy(true);
@@ -152,7 +299,7 @@ function PartyHomePage() {
                 </div>
                 <h1 className="font-display text-3xl font-bold text-slate-900 sm:text-4xl">Party Mode</h1>
                 <p className="mx-auto mt-2 max-w-md text-[15px] leading-relaxed text-slate-500">
-                    A live, Kahoot-style SAT quiz for you and your friends. One phone each — fastest correct answer wins.
+                    A live SAT quiz for you and your friends. One phone each — pick a game mode and go.
                 </p>
             </div>
 
@@ -161,7 +308,7 @@ function PartyHomePage() {
                     <div className="mt-8 grid gap-4 sm:grid-cols-2">
                         <button
                             type="button"
-                            onClick={() => setView('create')}
+                            onClick={openCreate}
                             className="group cursor-pointer rounded-3xl border-2 border-primary-200 bg-primary-50/60 p-6 text-left shadow-sm transition-all hover:border-primary-300 active:scale-[0.98] sm:p-7"
                         >
                             <span className="grid size-12 place-items-center rounded-2xl bg-primary-100">
@@ -190,7 +337,7 @@ function PartyHomePage() {
                     <div className="mt-12">
                         <h2 className="text-center font-display text-xl font-bold text-slate-900">How does this work?</h2>
                         <div className="mt-5 space-y-3">
-                            {STEPS.map(({icon: Icon, title, text}, index) => (
+                            {HOW_IT_WORKS.map(({icon: Icon, title, text}, index) => (
                                 <div key={title} className="flex gap-4 rounded-2xl border border-slate-200 bg-white p-4">
                                     <div className="relative shrink-0">
                                         <span className="grid size-11 place-items-center rounded-xl bg-primary-50">
@@ -222,70 +369,125 @@ function PartyHomePage() {
                 <div className="mt-8 rounded-3xl border border-slate-200 bg-white p-5 shadow-sm sm:p-7">
                     <button
                         type="button"
-                        onClick={() => setView('menu')}
+                        onClick={() => (step === 2 ? setStep(1) : setView('menu'))}
                         className="mb-4 inline-flex cursor-pointer items-center gap-1.5 text-sm font-semibold text-slate-500 hover:text-slate-800"
                     >
                         <ArrowLeft className="size-4"/> Back
                     </button>
-                    <h2 className="m-0 font-display text-xl font-bold text-slate-900">Room settings</h2>
 
-                    <div className="mt-5 space-y-5">
-                        <StepperInput
-                            label="Max players"
-                            hint={premium ? 'up to 50' : (
-                                <span className="inline-flex items-center gap-1">
-                                    up to 6 · <Crown className="size-3 text-amber-500"/> 50 with Premium
-                                </span>
-                            )}
-                            value={settings.max_players}
-                            onChange={set('max_players')}
-                            min={2}
-                            max={playerCap}
-                        />
-                        <StepperInput
-                            label="Number of questions"
-                            hint={premium ? 'up to 50' : (
-                                <span className="inline-flex items-center gap-1">
-                                    up to 20 · <Crown className="size-3 text-amber-500"/> 50 with Premium
-                                </span>
-                            )}
-                            value={settings.num_questions}
-                            onChange={set('num_questions')}
-                            min={1}
-                            max={questionCap}
-                        />
-                        <div>
-                            <span className="mb-1.5 block text-sm font-semibold text-slate-700">Time per question</span>
-                            <div className="grid grid-cols-5 gap-2">
-                                {TIMER_OPTIONS.map((seconds) => (
-                                    <button
-                                        key={seconds}
-                                        type="button"
-                                        onClick={() => set('seconds_per_question')(seconds)}
-                                        className={`cursor-pointer rounded-xl border-2 py-2.5 text-sm font-bold transition-colors ${
-                                            settings.seconds_per_question === seconds
-                                                ? 'border-primary-400 bg-primary-50 text-primary-800'
-                                                : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'
-                                        }`}
-                                    >
-                                        {seconds}s
-                                    </button>
+                    <StepBar step={step}/>
+
+                    {step === 1 ? (
+                        <>
+                            <h2 className="m-0 font-display text-xl font-bold text-slate-900">Choose a game mode</h2>
+                            <p className="mt-1 text-sm text-slate-500">
+                                Tap the <HelpCircle className="inline size-3.5 align-[-2px] text-slate-400"/> on any card
+                                to see how it plays.
+                            </p>
+                            <div className="mt-5 grid gap-4 sm:grid-cols-2">
+                                {PARTY_MODES.map((mode) => (
+                                    <ModeCard
+                                        key={mode.key}
+                                        mode={mode}
+                                        selected={settings.mode === mode.key}
+                                        onSelect={() => pickMode(mode.key)}
+                                        onDetails={() => setDetailMode(mode)}
+                                    />
                                 ))}
                             </div>
-                        </div>
-                        <div>
-                            <span className="mb-1.5 block text-sm font-semibold text-slate-700">Subject</span>
-                            <SegmentedControl options={SUBJECTS} value={settings.subject} onChange={set('subject')}/>
-                        </div>
-                        <div>
-                            <span className="mb-1.5 block text-sm font-semibold text-slate-700">Difficulty</span>
-                            <SegmentedControl options={DIFFICULTIES} value={settings.difficulty} onChange={set('difficulty')}/>
-                        </div>
-                    </div>
+                        </>
+                    ) : (
+                        <>
+                            <h2 className="m-0 font-display text-xl font-bold text-slate-900">Room settings</h2>
 
-                    <Button block size="lg" className="mt-7" loading={busy} onClick={createRoom}>
-                        Create room
-                    </Button>
+                            <div className="mt-5 space-y-5">
+                                {settings.mode === 'teams' && (
+                                    <>
+                                        <div>
+                                            <span className="mb-1.5 block text-sm font-semibold text-slate-700">
+                                                How many teams?
+                                            </span>
+                                            <SegmentedControl
+                                                options={TEAM_COUNTS}
+                                                value={String(settings.num_teams)}
+                                                onChange={(value) => setSettings((s) => ({
+                                                    ...s,
+                                                    num_teams: Number(value),
+                                                    max_players: Math.max(s.max_players, Number(value)),
+                                                }))}
+                                            />
+                                        </div>
+                                        <Toggle
+                                            checked={settings.random_teams}
+                                            onChange={set('random_teams')}
+                                            label="Shuffle teams automatically"
+                                            description={
+                                                settings.random_teams
+                                                    ? 'Players are split evenly at random when you start the game.'
+                                                    : 'You sort players into teams yourself in the lobby.'
+                                            }
+                                        />
+                                    </>
+                                )}
+                                <StepperInput
+                                    label="Max players"
+                                    hint={premium ? 'up to 50' : (
+                                        <span className="inline-flex items-center gap-1">
+                                            up to 6 · <Crown className="size-3 text-amber-500"/> 50 with Premium
+                                        </span>
+                                    )}
+                                    value={settings.max_players}
+                                    onChange={set('max_players')}
+                                    min={settings.mode === 'teams' ? settings.num_teams : 2}
+                                    max={playerCap}
+                                />
+                                <StepperInput
+                                    label="Number of questions"
+                                    hint={premium ? 'up to 50' : (
+                                        <span className="inline-flex items-center gap-1">
+                                            up to 20 · <Crown className="size-3 text-amber-500"/> 50 with Premium
+                                        </span>
+                                    )}
+                                    value={settings.num_questions}
+                                    onChange={set('num_questions')}
+                                    // Final Jeopardy needs a normal question before the bet.
+                                    min={settings.mode === 'jeopardy' ? 2 : 1}
+                                    max={questionCap}
+                                />
+                                <div>
+                                    <span className="mb-1.5 block text-sm font-semibold text-slate-700">Time per question</span>
+                                    <div className="grid grid-cols-5 gap-2">
+                                        {TIMER_OPTIONS.map((seconds) => (
+                                            <button
+                                                key={seconds}
+                                                type="button"
+                                                onClick={() => set('seconds_per_question')(seconds)}
+                                                className={`cursor-pointer rounded-xl border-2 py-2.5 text-sm font-bold transition-colors ${
+                                                    settings.seconds_per_question === seconds
+                                                        ? 'border-primary-400 bg-primary-50 text-primary-800'
+                                                        : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'
+                                                }`}
+                                            >
+                                                {seconds}s
+                                            </button>
+                                        ))}
+                                    </div>
+                                </div>
+                                <div>
+                                    <span className="mb-1.5 block text-sm font-semibold text-slate-700">Subject</span>
+                                    <SegmentedControl options={SUBJECTS} value={settings.subject} onChange={set('subject')}/>
+                                </div>
+                                <div>
+                                    <span className="mb-1.5 block text-sm font-semibold text-slate-700">Difficulty</span>
+                                    <SegmentedControl options={DIFFICULTIES} value={settings.difficulty} onChange={set('difficulty')}/>
+                                </div>
+                            </div>
+
+                            <Button block size="lg" className="mt-7" loading={busy} onClick={createRoom}>
+                                Create room
+                            </Button>
+                        </>
+                    )}
                 </div>
             )}
 
@@ -316,6 +518,12 @@ function PartyHomePage() {
                     </Button>
                 </div>
             )}
+
+            <ModeDetailModal
+                mode={detailMode}
+                onClose={() => setDetailMode(null)}
+                onPick={() => pickMode(detailMode.key)}
+            />
         </PageContainer>
     );
 }

--- a/src/pages/party/PartyRoomPage.jsx
+++ b/src/pages/party/PartyRoomPage.jsx
@@ -1,7 +1,7 @@
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useNavigate, useParams} from 'react-router-dom';
-import {Check, Copy, Crown, Users, X} from 'lucide-react';
-import {Button, Spinner} from '../../components/ui';
+import {BarChart3, BookOpen, Check, ChevronDown, Copy, Crown, Pencil, Shuffle, Users, X} from 'lucide-react';
+import {Button, ModalShell, Spinner} from '../../components/ui';
 import UserAvatar from '../../components/UserAvatar';
 import RenderWithMath from '../../components/RenderWithMath';
 import api from '../../components/api';
@@ -11,12 +11,30 @@ import '../../styles/party.css';
 const POLL_MS = 1000;
 const CHOICE_LABELS = ['A', 'B', 'C', 'D'];
 const MEDALS = ['🥇', '🥈', '🥉'];
+const TEAM_TONES = [
+    {chip: 'bg-violet-100 text-violet-700', bar: 'bg-violet-500', ring: 'border-violet-300', soft: 'bg-violet-50'},
+    {chip: 'bg-sky-100 text-sky-700', bar: 'bg-sky-500', ring: 'border-sky-300', soft: 'bg-sky-50'},
+    {chip: 'bg-amber-100 text-amber-700', bar: 'bg-amber-500', ring: 'border-amber-300', soft: 'bg-amber-50'},
+    {chip: 'bg-emerald-100 text-emerald-700', bar: 'bg-emerald-500', ring: 'border-emerald-300', soft: 'bg-emerald-50'},
+];
+const toneFor = (index) => TEAM_TONES[index % TEAM_TONES.length];
 
 const fmtClock = (s) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, '0')}`;
 
 function WaitingDots({children}) {
     return (
         <p className="m-0 animate-pulse text-center text-[15px] font-semibold text-slate-500">{children}</p>
+    );
+}
+
+/** Per-question score change. Losses only happen on a Final Jeopardy bet. */
+function DeltaBadge({points, className = 'text-xs'}) {
+    if (!points) return null;
+    const up = points > 0;
+    return (
+        <span className={`${className} font-bold ${up ? 'text-emerald-600' : 'text-rose-600'}`}>
+            {up ? `+${points}` : points}
+        </span>
     );
 }
 
@@ -35,9 +53,179 @@ function PlayerChip({player}) {
     );
 }
 
+function TeamNameField({team, editable, onRename}) {
+    const [draft, setDraft] = useState(null);
+    const tone = toneFor(team.index);
+
+    if (draft === null) {
+        return (
+            <button
+                type="button"
+                disabled={!editable}
+                onClick={() => setDraft(team.name)}
+                title={editable ? 'Rename this team' : undefined}
+                className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[13px] font-bold ${tone.chip} ${
+                    editable ? 'cursor-pointer hover:brightness-95' : ''
+                }`}
+            >
+                {team.name}
+                {editable && <Pencil className="size-3 opacity-60"/>}
+            </button>
+        );
+    }
+
+    const commit = () => {
+        const name = draft.trim();
+        setDraft(null);
+        if (name && name !== team.name) onRename(name);
+    };
+
+    return (
+        <input
+            autoFocus
+            value={draft}
+            maxLength={24}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commit}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter') commit();
+                if (e.key === 'Escape') setDraft(null);
+            }}
+            className="w-32 rounded-full border-2 border-slate-300 px-2.5 py-1 text-[13px] font-bold text-slate-800 outline-none focus:border-primary-400"
+        />
+    );
+}
+
+/**
+ * Host-only team sorter for the lobby.
+ *
+ * Tap-a-player-then-tap-a-team is the primary interaction — HTML5 drag events
+ * never fire on touch, and this is a phone-first feature. Drag is layered on
+ * top for anyone hosting from a laptop.
+ */
+function TeamSorter({state, teams, editable, selected, onSelect, onMove, onRename}) {
+    const unassigned = state.players.filter((p) => p.team == null);
+
+    const seat = (player, teamIndex) => (
+        <button
+            key={player.id}
+            type="button"
+            disabled={!editable}
+            draggable={editable}
+            onDragStart={() => onSelect(player.id)}
+            // Chips live inside a team's drop zone; without this, picking a player
+            // up also counts as dropping the previous one onto that team.
+            onClick={(e) => {
+                e.stopPropagation();
+                onSelect(selected === player.id ? null : player.id);
+            }}
+            className={`flex items-center gap-1.5 rounded-full border py-1 pl-1 pr-2.5 text-sm font-bold transition-all ${
+                selected === player.id
+                    ? 'border-primary-500 bg-primary-50 text-primary-800 ring-2 ring-primary-200'
+                    : 'border-slate-200 bg-white text-slate-800'
+            } ${editable ? 'cursor-pointer hover:border-slate-300' : ''}`}
+        >
+            <UserAvatar
+                backgroundId={player.avatar}
+                iconId={player.avatar_icon}
+                profile={{username: player.username}}
+                size="xs"
+                className="ring-0"
+            />
+            <span className="max-w-24 truncate">{player.username}</span>
+            {teamIndex == null && editable && <span className="text-[10px] text-slate-400">tap</span>}
+        </button>
+    );
+
+    const dropZone = (teamIndex, children, className) => (
+        <div
+            key={teamIndex ?? 'unassigned'}
+            onDragOver={(e) => editable && e.preventDefault()}
+            onDrop={() => editable && selected != null && onMove(selected, teamIndex)}
+            onClick={() => editable && selected != null && onMove(selected, teamIndex)}
+            className={className}
+        >
+            {children}
+        </div>
+    );
+
+    return (
+        <div className="mt-6">
+            {unassigned.length > 0 && dropZone(
+                null,
+                <>
+                    <p className="m-0 mb-2 text-[11px] font-bold uppercase tracking-wide text-slate-400">
+                        Not on a team yet
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                        {unassigned.map((player) => seat(player, null))}
+                    </div>
+                </>,
+                'rounded-2xl border-2 border-dashed border-slate-200 bg-white/60 p-3',
+            )}
+
+            <div className={`mt-3 grid gap-3 ${teams.length > 2 ? 'grid-cols-2' : 'grid-cols-1 sm:grid-cols-2'}`}>
+                {teams.map((team) => {
+                    const tone = toneFor(team.index);
+                    const members = state.players.filter((p) => p.team === team.index);
+                    return dropZone(
+                        team.index,
+                        <>
+                            <div className="mb-2 flex items-center justify-between gap-2">
+                                <TeamNameField team={team} editable={editable} onRename={(name) => onRename(team.index, name)}/>
+                                <span className="text-[11px] font-bold text-slate-400">{members.length}</span>
+                            </div>
+                            <div className="flex flex-wrap gap-2">
+                                {members.length === 0
+                                    ? <span className="text-[13px] text-slate-400">Empty</span>
+                                    : members.map((player) => seat(player, team.index))}
+                            </div>
+                        </>,
+                        `rounded-2xl border-2 p-3 transition-colors ${tone.ring} ${tone.soft} ${
+                            editable && selected != null ? 'cursor-pointer ring-2 ring-primary-200' : ''
+                        }`,
+                    );
+                })}
+            </div>
+
+            {editable && (
+                <p className="m-0 mt-2 text-center text-xs text-slate-400">
+                    {selected != null
+                        ? 'Now tap a team to move them there.'
+                        : 'Tap a player, then tap a team. Or drag them across.'}
+                </p>
+            )}
+        </div>
+    );
+}
+
 function Lobby({state, roomId, onLeave}) {
     const [starting, setStarting] = useState(false);
+    const [selected, setSelected] = useState(null);
     const {settings} = state;
+    const isTeams = state.mode === 'teams';
+    const canSort = isTeams && state.is_host && !settings.random_teams;
+
+    const postTeams = async (payload) => {
+        try {
+            await api.post(`/api/party/${roomId}/teams/`, payload);
+        } catch (error) {
+            notify.error(error.response?.data?.error || 'Could not update the teams.');
+        }
+    };
+
+    const moveTo = (userId, teamIndex) => {
+        setSelected(null);
+        postTeams({assignments: {[userId]: teamIndex}});
+    };
+
+    const rename = (index, name) => {
+        const names = (state.teams || []).slice()
+            .sort((a, b) => a.index - b.index)
+            .map((team) => team.name);
+        names[index] = name;
+        postTeams({names});
+    };
 
     const copyCode = async () => {
         try {
@@ -92,12 +280,31 @@ function Lobby({state, roomId, onLeave}) {
                 </p>
             </div>
 
-            <div className="mt-8 flex flex-wrap items-center justify-center gap-2">
-                {state.players.map((player) => <PlayerChip key={player.id} player={player}/>)}
-            </div>
+            {isTeams ? (
+                <TeamSorter
+                    state={state}
+                    teams={(state.teams || []).slice().sort((a, b) => a.index - b.index)}
+                    editable={canSort}
+                    selected={selected}
+                    onSelect={setSelected}
+                    onMove={moveTo}
+                    onRename={rename}
+                />
+            ) : (
+                <div className="mt-8 flex flex-wrap items-center justify-center gap-2">
+                    {state.players.map((player) => <PlayerChip key={player.id} player={player}/>)}
+                </div>
+            )}
+
+            {isTeams && settings.random_teams && (
+                <p className="m-0 mt-3 flex items-center justify-center gap-1.5 text-center text-[13px] font-semibold text-slate-400">
+                    <Shuffle className="size-3.5"/> Teams are shuffled when the game starts.
+                </p>
+            )}
 
             <div className="mt-auto pt-8">
                 <div className="mb-4 flex flex-wrap justify-center gap-x-4 gap-y-1 text-[13px] font-semibold text-slate-400">
+                    {isTeams && <><span>{settings.num_teams} teams</span><span>·</span></>}
                     <span className="capitalize">{settings.subject === 'mixed' ? 'Math + English' : settings.subject}</span>
                     <span>·</span>
                     <span className="capitalize">{settings.difficulty}</span>
@@ -128,6 +335,105 @@ function Countdown({secondsLeft}) {
             <div key={digit} className="party-pop text-center">
                 <p className="m-0 text-[9rem] font-black leading-none text-primary-600">{digit}</p>
                 <p className="m-0 mt-2 text-lg font-bold uppercase tracking-[0.3em] text-slate-400">Get ready</p>
+            </div>
+        </div>
+    );
+}
+
+function WagerPhase({state, roomId, secondsLeft}) {
+    const info = state.wager || {};
+    const maxBet = Math.max(0, info.your_score || 0);
+    const [amount, setAmount] = useState(0);
+    const [sending, setSending] = useState(false);
+    const locked = info.locked;
+
+    const place = async () => {
+        setSending(true);
+        try {
+            await api.post(`/api/party/${roomId}/wager/`, {amount});
+        } catch (error) {
+            const message = error.response?.data?.error;
+            if (message && message !== 'You already placed your bet.') notify.error(message);
+        } finally {
+            setSending(false);
+        }
+    };
+
+    return (
+        <div className="mx-auto flex min-h-dvh w-full max-w-xl flex-col justify-center px-5 py-8">
+            <div className="text-center">
+                <p className="m-0 text-sm font-bold uppercase tracking-[0.25em] text-amber-600">Final question</p>
+                <h1 className="m-0 mt-2 font-display text-3xl font-black text-slate-900">Place your bet</h1>
+                <p className="mx-auto mt-2 max-w-sm text-[15px] leading-relaxed text-slate-500">
+                    Win it and your bet pays back double. Lose it and it&apos;s gone.
+                    On this question, answering faster earns no extra points.
+                </p>
+            </div>
+
+            <div className="mt-7 rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+                <div className="flex items-baseline justify-between">
+                    <span className="text-sm font-semibold text-slate-500">Your score</span>
+                    <span className="font-mono text-2xl font-black text-slate-900">{maxBet}</span>
+                </div>
+
+                {maxBet === 0 ? (
+                    <p className="m-0 mt-4 text-center text-sm font-semibold text-slate-500">
+                        You have nothing to bet this round — answer correctly to get back in it.
+                    </p>
+                ) : locked ? (
+                    <div className="mt-5 text-center">
+                        <p className="m-0 text-sm font-semibold text-slate-500">Your bet is locked in</p>
+                        <p className="m-0 mt-1 font-mono text-4xl font-black text-amber-600">{info.your_wager}</p>
+                    </div>
+                ) : (
+                    <>
+                        <p className="m-0 mt-5 text-center font-mono text-5xl font-black text-amber-600">{amount}</p>
+                        <input
+                            type="range"
+                            min={0}
+                            max={maxBet}
+                            step={Math.max(1, Math.round(maxBet / 100))}
+                            value={amount}
+                            onChange={(e) => setAmount(Number(e.target.value))}
+                            aria-label="Bet amount"
+                            className="mt-4 h-2 w-full cursor-pointer appearance-none rounded-full bg-slate-200 accent-amber-500"
+                        />
+                        <div className="mt-3 grid grid-cols-4 gap-2">
+                            {[
+                                ['None', 0],
+                                ['¼', Math.floor(maxBet / 4)],
+                                ['Half', Math.floor(maxBet / 2)],
+                                ['All in', maxBet],
+                            ].map(([label, value]) => (
+                                <button
+                                    key={label}
+                                    type="button"
+                                    onClick={() => setAmount(value)}
+                                    className={`cursor-pointer rounded-xl border-2 py-2 text-sm font-bold transition-colors ${
+                                        amount === value
+                                            ? 'border-amber-400 bg-amber-50 text-amber-700'
+                                            : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'
+                                    }`}
+                                >
+                                    {label}
+                                </button>
+                            ))}
+                        </div>
+                        <Button block size="lg" className="mt-5" loading={sending} onClick={place}>
+                            Lock in {amount}
+                        </Button>
+                    </>
+                )}
+            </div>
+
+            <div className="mt-6 text-center">
+                <p className="m-0 font-mono text-lg font-bold text-slate-700">{fmtClock(secondsLeft)}</p>
+                <p className="m-0 mt-1 text-xs font-semibold text-slate-400">
+                    {info.waiting_on > 0
+                        ? `Waiting on ${info.waiting_on} more ${info.waiting_on === 1 ? 'bet' : 'bets'}…`
+                        : 'All bets are in.'}
+                    {' '}Unplaced bets count as zero when time runs out.
+                </p>
             </div>
         </div>
     );
@@ -166,6 +472,14 @@ function QuestionPhase({state, roomId, secondsLeft}) {
 
     return (
         <div className="mx-auto flex min-h-dvh w-full max-w-3xl flex-col px-4 py-4 sm:py-6">
+            {state.is_final_question && (
+                <div className="mb-3 flex items-center justify-center gap-2 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-2">
+                    <span className="text-[13px] font-bold uppercase tracking-wide text-amber-700">Final question</span>
+                    <span className="text-[13px] font-semibold text-amber-600">
+                        · {state.your_wager} on the line · speed doesn&apos;t count
+                    </span>
+                </div>
+            )}
             <div className="flex items-center justify-between gap-3">
                 <span className="rounded-full border border-slate-200 bg-white px-3.5 py-1.5 text-sm font-bold text-slate-700">
                     Q {state.question_number}/{state.total_questions}
@@ -240,8 +554,194 @@ function QuestionPhase({state, roomId, secondsLeft}) {
     );
 }
 
+function AnswerSpread({reveal, playerCount}) {
+    const [open, setOpen] = useState(false);
+    const counts = reveal.distribution || {};
+    const gotItRight = counts[reveal.correct_choice] || 0;
+    const busiest = Math.max(1, ...CHOICE_LABELS.map((letter) => counts[letter] || 0));
+
+    return (
+        <div className="mt-3 overflow-hidden rounded-2xl border border-slate-200 bg-white">
+            <button
+                type="button"
+                onClick={() => setOpen((v) => !v)}
+                aria-expanded={open}
+                className="flex w-full cursor-pointer items-center gap-2.5 px-3.5 py-2.5 text-left hover:bg-slate-50"
+            >
+                <BarChart3 className="size-4 shrink-0 text-slate-400"/>
+                <span className="flex-1 text-[13px] font-bold text-slate-700">
+                    {gotItRight} of {playerCount} got it right
+                </span>
+                <ChevronDown className={`size-4 text-slate-400 transition-transform ${open ? 'rotate-180' : ''}`}/>
+            </button>
+
+            {open && (
+                <div className="space-y-1.5 border-t border-slate-100 px-3.5 py-3">
+                    {CHOICE_LABELS.map((letter) => {
+                        const count = counts[letter] || 0;
+                        const isCorrect = letter === reveal.correct_choice;
+                        const isYours = letter === reveal.your_choice;
+                        return (
+                            <div key={letter} className="flex items-center gap-2.5">
+                                <span
+                                    className={`grid size-6 shrink-0 place-items-center rounded-full text-[11px] font-bold ${
+                                        isCorrect ? 'bg-emerald-500 text-white' : 'bg-slate-100 text-slate-500'
+                                    }`}
+                                >
+                                    {letter}
+                                </span>
+                                <div className="h-2.5 flex-1 overflow-hidden rounded-full bg-slate-100">
+                                    <div
+                                        className={`h-full rounded-full transition-all ${
+                                            isCorrect ? 'bg-emerald-500' : 'bg-slate-300'
+                                        }`}
+                                        style={{width: `${(count / busiest) * 100}%`}}
+                                    />
+                                </div>
+                                <span className="w-4 text-right text-[11px] font-bold text-slate-500">{count}</span>
+                                <span className="w-8 text-[10px] font-bold uppercase text-primary-600">
+                                    {isYours ? 'you' : ''}
+                                </span>
+                            </div>
+                        );
+                    })}
+                    {reveal.skipped > 0 && (
+                        <p className="m-0 pt-1 text-[11px] text-slate-400">
+                            {reveal.skipped} didn&apos;t answer in time.
+                        </p>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function ReviewModal({reveal, onClose}) {
+    const review = reveal.review || {};
+    return (
+        <ModalShell open title="Question review" onClose={onClose} maxWidth="max-w-2xl">
+            <div className="text-[15px] leading-relaxed text-slate-900">
+                <RenderWithMath text={review.question || ''}/>
+            </div>
+
+            <div className="mt-4 space-y-2">
+                {(review.choices || []).map((choice, index) => {
+                    const letter = CHOICE_LABELS[index];
+                    const isCorrect = letter === reveal.correct_choice;
+                    const isYourMistake = letter === reveal.your_choice && !reveal.correct;
+                    return (
+                        <div
+                            key={letter}
+                            className={`flex items-start gap-3 rounded-2xl border-2 px-3.5 py-2.5 ${
+                                isCorrect
+                                    ? 'border-emerald-300 bg-emerald-50'
+                                    : isYourMistake
+                                        ? 'border-rose-300 bg-rose-50'
+                                        : 'border-slate-200 bg-white'
+                            }`}
+                        >
+                            <span
+                                className={`grid size-6 shrink-0 place-items-center rounded-full text-[11px] font-bold ${
+                                    isCorrect
+                                        ? 'bg-emerald-500 text-white'
+                                        : isYourMistake
+                                            ? 'bg-rose-500 text-white'
+                                            : 'border-2 border-slate-300 text-slate-500'
+                                }`}
+                            >
+                                {letter}
+                            </span>
+                            <span className="min-w-0 flex-1 text-sm font-semibold leading-snug text-slate-900">
+                                <RenderWithMath text={choice}/>
+                            </span>
+                            {isCorrect && (
+                                <span className="shrink-0 text-[10px] font-bold uppercase text-emerald-600">correct</span>
+                            )}
+                            {isYourMistake && (
+                                <span className="shrink-0 text-[10px] font-bold uppercase text-rose-600">your pick</span>
+                            )}
+                        </div>
+                    );
+                })}
+            </div>
+
+            {review.explanation && (
+                <div className="mt-4 rounded-2xl bg-slate-50 p-4">
+                    <p className="m-0 text-[11px] font-bold uppercase tracking-wide text-slate-400">Explanation</p>
+                    <div className="mt-1.5 text-sm leading-relaxed text-slate-700">
+                        <RenderWithMath text={review.explanation}/>
+                    </div>
+                </div>
+            )}
+        </ModalShell>
+    );
+}
+
+function TeamStandings({teams}) {
+    return (
+        <div className="space-y-2.5">
+            {teams.map((team, rank) => {
+                const tone = toneFor(team.index);
+                const scored = team.members.filter((m) => m.score > 0);
+                return (
+                    <div
+                        key={team.index}
+                        className="party-fade-up rounded-2xl border border-slate-200 bg-white p-3.5 shadow-sm"
+                        style={{animationDelay: `${rank * 70}ms`}}
+                    >
+                        <div className="flex items-center gap-3">
+                            <span className="w-7 text-center text-lg">
+                                {MEDALS[rank] || <span className="text-sm font-bold text-slate-400">{rank + 1}</span>}
+                            </span>
+                            <span className={`rounded-full px-2.5 py-1 text-[13px] font-bold ${tone.chip}`}>
+                                {team.name}
+                            </span>
+                            <span className="flex-1"/>
+                            <DeltaBadge points={team.last_points}/>
+                            <span className="font-mono text-[15px] font-bold text-slate-800">{team.score}</span>
+                        </div>
+
+                        {/* Who actually built that score. */}
+                        {scored.length > 0 && (
+                            <div className="mt-2.5 flex h-1.5 overflow-hidden rounded-full bg-slate-100">
+                                {scored.map((member) => (
+                                    <span
+                                        key={member.id}
+                                        className={`${tone.bar} border-r border-white last:border-0`}
+                                        style={{width: `${(member.score / team.score) * 100}%`}}
+                                        title={`${member.username}: ${member.score}`}
+                                    />
+                                ))}
+                            </div>
+                        )}
+                        <div className="mt-2 space-y-1">
+                            {team.members.map((member) => (
+                                <div key={member.id} className="flex items-center gap-2 pl-10 text-[13px]">
+                                    <UserAvatar
+                                        backgroundId={member.avatar}
+                                        iconId={member.avatar_icon}
+                                        profile={{username: member.username}}
+                                        size="xs"
+                                        className="ring-0"
+                                    />
+                                    <span className="min-w-0 flex-1 truncate font-semibold text-slate-600">
+                                        {member.username}
+                                    </span>
+                                    <DeltaBadge points={member.last_points} className="text-[11px]"/>
+                                    <span className="font-mono font-bold text-slate-500">{member.score}</span>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}
+
 function Leaderboard({state, roomId}) {
     const [advancing, setAdvancing] = useState(false);
+    const [reviewing, setReviewing] = useState(false);
     const reveal = state.reveal || {};
 
     const next = async () => {
@@ -276,30 +776,51 @@ function Leaderboard({state, roomId}) {
                         Answer: {reveal.correct_choice} — <span className="inline-block max-w-full align-bottom"><RenderWithMath text={reveal.correct_text || ''}/></span>
                     </div>
                 )}
+                {reveal.was_final_bet && reveal.wager > 0 && (
+                    <p className={`m-0 mt-2 text-sm font-bold ${reveal.correct ? 'text-emerald-700' : 'text-rose-700'}`}>
+                        {reveal.correct
+                            ? `Your ${reveal.wager} bet paid back double.`
+                            : `You lost your ${reveal.wager} bet.`}
+                    </p>
+                )}
             </div>
 
-            <div className="mt-5 flex-1 space-y-2 overflow-y-auto">
-                {state.players.map((player, index) => (
-                    <div
-                        key={player.id}
-                        className="party-fade-up flex items-center gap-3 rounded-2xl border border-slate-200 bg-white px-3.5 py-2.5 shadow-sm"
-                        style={{animationDelay: `${index * 70}ms`}}
-                    >
-                        <span className="w-7 text-center text-lg">{MEDALS[index] || <span className="text-sm font-bold text-slate-400">{index + 1}</span>}</span>
-                        <UserAvatar
-                            backgroundId={player.avatar}
-                            iconId={player.avatar_icon}
-                            profile={{username: player.username}}
-                            size="xs"
-                            className="ring-0"
-                        />
-                        <span className="min-w-0 flex-1 truncate text-[15px] font-bold text-slate-900">{player.username}</span>
-                        {player.last_points > 0 && (
-                            <span className="text-xs font-bold text-emerald-600">+{player.last_points}</span>
-                        )}
-                        <span className="font-mono text-[15px] font-bold text-slate-700">{player.score}</span>
+            <AnswerSpread reveal={reveal} playerCount={state.players.length}/>
+
+            <button
+                type="button"
+                onClick={() => setReviewing(true)}
+                className="mt-2 flex w-full cursor-pointer items-center justify-center gap-2 rounded-2xl border border-slate-200 bg-white px-3.5 py-2.5 text-[13px] font-bold text-slate-600 hover:border-slate-300 hover:text-slate-900"
+            >
+                <BookOpen className="size-4 text-slate-400"/> Review this question
+            </button>
+
+            <div className="mt-5 flex-1 overflow-y-auto">
+                {state.mode === 'teams' && state.teams ? (
+                    <TeamStandings teams={state.teams}/>
+                ) : (
+                    <div className="space-y-2">
+                        {state.players.map((player, index) => (
+                            <div
+                                key={player.id}
+                                className="party-fade-up flex items-center gap-3 rounded-2xl border border-slate-200 bg-white px-3.5 py-2.5 shadow-sm"
+                                style={{animationDelay: `${index * 70}ms`}}
+                            >
+                                <span className="w-7 text-center text-lg">{MEDALS[index] || <span className="text-sm font-bold text-slate-400">{index + 1}</span>}</span>
+                                <UserAvatar
+                                    backgroundId={player.avatar}
+                                    iconId={player.avatar_icon}
+                                    profile={{username: player.username}}
+                                    size="xs"
+                                    className="ring-0"
+                                />
+                                <span className="min-w-0 flex-1 truncate text-[15px] font-bold text-slate-900">{player.username}</span>
+                                <DeltaBadge points={player.last_points}/>
+                                <span className="font-mono text-[15px] font-bold text-slate-700">{player.score}</span>
+                            </div>
+                        ))}
                     </div>
-                ))}
+                )}
             </div>
 
             <div className="pt-5">
@@ -311,17 +832,37 @@ function Leaderboard({state, roomId}) {
                     <WaitingDots>Waiting for {state.host_username}…</WaitingDots>
                 )}
             </div>
+
+            {reviewing && <ReviewModal reveal={reveal} onClose={() => setReviewing(false)}/>}
         </div>
     );
 }
 
 function Podium({state, onExit}) {
-    const [top1, top2, top3] = state.players;
-    const rest = state.players.slice(3);
+    const isTeams = state.mode === 'teams' && Boolean(state.teams);
+    // Teams podium the teams; everyone else podiums the players.
+    const entries = useMemo(() => (
+        isTeams
+            ? state.teams.map((team) => ({
+                key: `team-${team.index}`,
+                label: team.name,
+                score: team.score,
+                team,
+            }))
+            : state.players.map((player) => ({
+                key: player.id,
+                label: player.username,
+                score: player.score,
+                player,
+            }))
+    ), [isTeams, state.teams, state.players]);
+
+    const [top1, top2, top3] = entries;
+    const rest = entries.slice(3);
     const columns = [
-        {player: top2, place: 2, height: 'h-28', delay: '0.35s', tone: 'bg-slate-200'},
-        {player: top1, place: 1, height: 'h-40', delay: '0.75s', tone: 'bg-amber-200'},
-        {player: top3, place: 3, height: 'h-20', delay: '0s', tone: 'bg-orange-100'},
+        {entry: top2, place: 2, height: 'h-28', delay: '0.35s', tone: 'bg-slate-200'},
+        {entry: top1, place: 1, height: 'h-40', delay: '0.75s', tone: 'bg-amber-200'},
+        {entry: top3, place: 3, height: 'h-20', delay: '0s', tone: 'bg-orange-100'},
     ];
 
     return (
@@ -329,19 +870,27 @@ function Podium({state, onExit}) {
             <h1 className="m-0 text-center font-display text-3xl font-black text-slate-900">Final results</h1>
 
             <div className="mt-10 flex items-end justify-center gap-3">
-                {columns.map(({player, place, height, delay, tone}) => player ? (
+                {columns.map(({entry, place, height, delay, tone}) => entry ? (
                     <div key={place} className="flex w-1/3 max-w-36 flex-col items-center">
                         <div className={`mb-2 text-center ${place === 1 ? 'party-bounce' : ''}`}>
                             {place === 1 && <Crown className="mx-auto mb-1 size-7 fill-amber-400 text-amber-400"/>}
-                            <UserAvatar
-                                backgroundId={player.avatar}
-                                iconId={player.avatar_icon}
-                                profile={{username: player.username}}
-                                size="sm"
-                                className="mx-auto ring-2 ring-slate-200"
-                            />
-                            <p className="m-0 mt-1 max-w-32 truncate text-sm font-bold text-slate-800">{player.username}</p>
-                            <p className="m-0 font-mono text-lg font-black text-slate-900">{player.score}</p>
+                            {entry.team ? (
+                                <span
+                                    className={`mx-auto grid size-11 place-items-center rounded-2xl text-lg font-black ${toneFor(entry.team.index).chip}`}
+                                >
+                                    {entry.label.charAt(0).toUpperCase()}
+                                </span>
+                            ) : (
+                                <UserAvatar
+                                    backgroundId={entry.player.avatar}
+                                    iconId={entry.player.avatar_icon}
+                                    profile={{username: entry.label}}
+                                    size="sm"
+                                    className="mx-auto ring-2 ring-slate-200"
+                                />
+                            )}
+                            <p className="m-0 mt-1 max-w-32 truncate text-sm font-bold text-slate-800">{entry.label}</p>
+                            <p className="m-0 font-mono text-lg font-black text-slate-900">{entry.score}</p>
                         </div>
                         <div
                             className={`party-podium-bar w-full rounded-t-2xl ${height} ${tone} grid place-items-start justify-center pt-2 text-2xl`}
@@ -355,13 +904,22 @@ function Podium({state, onExit}) {
 
             {rest.length > 0 && (
                 <div className="mt-8 space-y-2">
-                    {rest.map((player, index) => (
-                        <div key={player.id} className="flex items-center gap-3 rounded-2xl border border-slate-200 bg-white px-3.5 py-2 text-slate-800">
+                    {rest.map((entry, index) => (
+                        <div key={entry.key} className="flex items-center gap-3 rounded-2xl border border-slate-200 bg-white px-3.5 py-2 text-slate-800">
                             <span className="w-6 text-center text-sm font-bold text-slate-400">{index + 4}</span>
-                            <span className="min-w-0 flex-1 truncate text-[15px] font-semibold">{player.username}</span>
-                            <span className="font-mono font-bold">{player.score}</span>
+                            <span className="min-w-0 flex-1 truncate text-[15px] font-semibold">{entry.label}</span>
+                            <span className="font-mono font-bold">{entry.score}</span>
                         </div>
                     ))}
+                </div>
+            )}
+
+            {isTeams && (
+                <div className="mt-8">
+                    <p className="m-0 mb-3 text-center text-[11px] font-bold uppercase tracking-wide text-slate-400">
+                        Who scored what
+                    </p>
+                    <TeamStandings teams={state.teams}/>
                 </div>
             )}
 
@@ -440,6 +998,8 @@ function PartyRoomPage() {
         content = <Lobby state={state} roomId={roomId} onLeave={leave}/>;
     } else if (state.status === 'countdown') {
         content = <Countdown secondsLeft={secondsLeft}/>;
+    } else if (state.status === 'wager') {
+        content = <WagerPhase state={state} roomId={roomId} secondsLeft={secondsLeft}/>;
     } else if (state.status === 'question') {
         content = <QuestionPhase state={state} roomId={roomId} secondsLeft={secondsLeft}/>;
     } else if (state.status === 'leaderboard') {

--- a/src/pages/party/modes.jsx
+++ b/src/pages/party/modes.jsx
@@ -1,0 +1,183 @@
+import React from 'react';
+
+/**
+ * Party game modes: artwork, copy, and the settings each one cares about.
+ *
+ * Art is inline SVG so it themes with the card accent and ships no assets.
+ * Gradient ids are namespaced per mode — two cards on screen would otherwise
+ * fight over the same defs id and both render with the first one's colors.
+ */
+
+function ClassicArt() {
+    return (
+        <svg viewBox="0 0 140 84" fill="none" className="h-full w-full" aria-hidden="true">
+            <defs>
+                <linearGradient id="party-art-classic" x1="0" y1="1" x2="0" y2="0">
+                    <stop offset="0%" stopColor="currentColor" stopOpacity="0.25"/>
+                    <stop offset="100%" stopColor="currentColor" stopOpacity="0.9"/>
+                </linearGradient>
+            </defs>
+            {[
+                {x: 26, h: 30}, {x: 54, h: 52}, {x: 82, h: 40}, {x: 110, h: 22},
+            ].map(({x, h}) => (
+                <rect key={x} x={x - 9} y={70 - h} width="18" height={h} rx="5"
+                      fill="url(#party-art-classic)"/>
+            ))}
+            <path d="M14 70h116" stroke="currentColor" strokeOpacity="0.35" strokeWidth="2.5"
+                  strokeLinecap="round"/>
+            <path d="M52 8l-13 22h11l-3 16 14-23H50l2-15z" fill="currentColor"/>
+            <circle cx="110" cy="26" r="3" fill="currentColor" fillOpacity="0.45"/>
+            <circle cx="26" cy="30" r="2.5" fill="currentColor" fillOpacity="0.3"/>
+        </svg>
+    );
+}
+
+function TeamsArt() {
+    return (
+        <svg viewBox="0 0 140 84" fill="none" className="h-full w-full" aria-hidden="true">
+            <defs>
+                <linearGradient id="party-art-teams-l" x1="0" y1="0" x2="1" y2="1">
+                    <stop offset="0%" stopColor="currentColor" stopOpacity="0.85"/>
+                    <stop offset="100%" stopColor="currentColor" stopOpacity="0.4"/>
+                </linearGradient>
+                <linearGradient id="party-art-teams-r" x1="1" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="currentColor" stopOpacity="0.7"/>
+                    <stop offset="100%" stopColor="currentColor" stopOpacity="0.25"/>
+                </linearGradient>
+            </defs>
+            <path d="M10 14h46v42l-23-11-23 11z" fill="url(#party-art-teams-l)"/>
+            <path d="M84 14h46v42l-23-11-23 11z" fill="url(#party-art-teams-r)"/>
+            <circle cx="24" cy="30" r="5" fill="currentColor" fillOpacity="0.55"/>
+            <circle cx="42" cy="30" r="5" fill="currentColor" fillOpacity="0.55"/>
+            <circle cx="98" cy="30" r="5" fill="currentColor" fillOpacity="0.45"/>
+            <circle cx="116" cy="30" r="5" fill="currentColor" fillOpacity="0.45"/>
+            <path d="M64 34l6-6m0 0l6 6m-6-6v22" stroke="currentColor" strokeOpacity="0.5"
+                  strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+            <path d="M70 68h0" stroke="currentColor" strokeWidth="5" strokeLinecap="round"/>
+        </svg>
+    );
+}
+
+function SurvivalArt() {
+    const heart = 'M0 8c0-4 3-7 7-7 3 0 5 2 6 4 1-2 3-4 6-4 4 0 7 3 7 7 0 8-9 13-13 16C9 21 0 16 0 8z';
+    return (
+        <svg viewBox="0 0 140 84" fill="none" className="h-full w-full" aria-hidden="true">
+            <g transform="translate(18 26)" fill="currentColor" fillOpacity="0.9">
+                <path d={heart}/>
+            </g>
+            <g transform="translate(58 26)" fill="currentColor" fillOpacity="0.6">
+                <path d={heart}/>
+            </g>
+            {/* The third heart is cracking — the mode's whole premise in one glyph. */}
+            <g transform="translate(98 26)">
+                <path d={heart} fill="currentColor" fillOpacity="0.16"/>
+                <path d={heart} stroke="currentColor" strokeOpacity="0.5" strokeWidth="1.5"
+                      strokeDasharray="4 3" fill="none"/>
+                <path d="M13 2l-4 9h6l-5 10" stroke="currentColor" strokeOpacity="0.75"
+                      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none"/>
+            </g>
+            <path d="M16 68h108" stroke="currentColor" strokeOpacity="0.25" strokeWidth="2.5"
+                  strokeLinecap="round"/>
+        </svg>
+    );
+}
+
+function JeopardyArt() {
+    return (
+        <svg viewBox="0 0 140 84" fill="none" className="h-full w-full" aria-hidden="true">
+            <defs>
+                <linearGradient id="party-art-jeopardy" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="currentColor" stopOpacity="0.3"/>
+                    <stop offset="100%" stopColor="currentColor" stopOpacity="0"/>
+                </linearGradient>
+            </defs>
+            {/* Spotlight cone over the final wager. */}
+            <path d="M70 0L104 74H36z" fill="url(#party-art-jeopardy)"/>
+            {[0, 1, 2].map((i) => (
+                <ellipse key={i} cx="70" cy={62 - i * 9} rx="22" ry="7"
+                         fill="currentColor" fillOpacity={0.25 + i * 0.2}/>
+            ))}
+            <text x="70" y="30" textAnchor="middle" fill="currentColor"
+                  fontSize="20" fontWeight="800" fontFamily="inherit">×2</text>
+            <circle cx="28" cy="18" r="2.5" fill="currentColor" fillOpacity="0.4"/>
+            <circle cx="114" cy="24" r="2" fill="currentColor" fillOpacity="0.3"/>
+        </svg>
+    );
+}
+
+export const PARTY_MODES = [
+    {
+        key: 'classic',
+        name: 'Classic',
+        tagline: 'Fastest correct answer wins.',
+        Art: ClassicArt,
+        available: true,
+        // Tailwind needs literal class names, so each mode carries its own.
+        text: 'text-primary-600',
+        card: 'border-primary-200 bg-gradient-to-br from-primary-50 to-white',
+        cardOn: 'border-primary-500 bg-gradient-to-br from-primary-100 to-primary-50 ring-2 ring-primary-200',
+        summary: 'Everyone races the same question. A Kahoot-style free-for-all.',
+        how: [
+            'Every player sees the same question at the same time.',
+            'Correct answers score 500–1000 points — lock in faster, score higher.',
+            'Standings pop up after each question, and the game ends on a podium.',
+        ],
+        bestFor: 'Any group. The one to start with if nobody has played before.',
+    },
+    {
+        key: 'teams',
+        name: 'Teams',
+        tagline: 'Two to four squads, one score.',
+        Art: TeamsArt,
+        available: true,
+        text: 'text-violet-600',
+        card: 'border-violet-200 bg-gradient-to-br from-violet-50 to-white',
+        cardOn: 'border-violet-500 bg-gradient-to-br from-violet-100 to-violet-50 ring-2 ring-violet-200',
+        summary: 'Players split into squads. Every point feeds the team total.',
+        how: [
+            'Pick 2–4 teams. Shuffle them randomly, or sort everyone by hand in the lobby.',
+            'The host can rename any team before the game starts.',
+            'Scoring works exactly like Classic — points just roll up to the team.',
+            'The leaderboard ranks teams, and expands to show who contributed what.',
+        ],
+        bestFor: 'Bigger rooms and classrooms. Nobody feels singled out for a wrong answer.',
+    },
+    {
+        key: 'survival',
+        name: 'Survival',
+        tagline: 'Miss too many and you are out.',
+        Art: SurvivalArt,
+        available: false,
+        text: 'text-rose-600',
+        card: 'border-rose-200 bg-gradient-to-br from-rose-50 to-white',
+        cardOn: 'border-rose-500 bg-gradient-to-br from-rose-100 to-rose-50 ring-2 ring-rose-200',
+        summary: 'Everyone starts with hearts. A wrong answer costs one.',
+        how: [
+            'Each player starts with the same number of hearts.',
+            'Wrong answer — or running out the clock — costs a heart.',
+            'Last player standing wins, or play a fixed set and see who has the most hearts left.',
+        ],
+        bestFor: 'Late in a party, when you want the room watching one screen.',
+    },
+    {
+        key: 'jeopardy',
+        name: 'Final Jeopardy',
+        tagline: 'Bet it all on the last question.',
+        Art: JeopardyArt,
+        available: true,
+        text: 'text-amber-600',
+        card: 'border-amber-200 bg-gradient-to-br from-amber-50 to-white',
+        cardOn: 'border-amber-500 bg-gradient-to-br from-amber-100 to-amber-50 ring-2 ring-amber-200',
+        summary: 'Classic rules, until the last question turns into a wager.',
+        how: [
+            'Plays exactly like Classic right up to the final question.',
+            'Before that question, everyone secretly bets part of their score.',
+            'Get it right and your bet is paid back double. Get it wrong and it is gone.',
+            'On the final question only, answering faster earns no extra points — take your time.',
+            'Nobody is ever mathematically out of it, so the room stays in until the end.',
+        ],
+        bestFor: 'Groups where one person would otherwise run away with it.',
+    },
+];
+
+export const MODES_BY_KEY = Object.fromEntries(PARTY_MODES.map((mode) => [mode.key, mode]));

--- a/src/pages/practice_test/PracticeTestPage.jsx
+++ b/src/pages/practice_test/PracticeTestPage.jsx
@@ -2,7 +2,6 @@ import React, {useEffect, useState} from 'react';
 import {ArrowRight, Info} from 'lucide-react';
 import {useLocation, useNavigate} from 'react-router-dom';
 import {useAuth} from '../../context/AuthContext';
-import api from '../../components/api';
 import {Alert, Button, Card, PageContainer} from '../../components/ui';
 
 const TESTS = [
@@ -90,17 +89,11 @@ function PracticeTestPage() {
         );
     }, [location, user]);
 
-    const closeFirstRunBanner = async () => {
+    const closeFirstRunBanner = () => {
         setShowFirstRunBanner(false);
-        if (user?.is_first_login) {
-            try {
-                await api.post('api/profile/update_first_login/');
-                localStorage.setItem('is_first_login', 'false');
-                setFirstLogin();
-            } catch (error) {
-                console.error('Failed to update first login status:', error);
-            }
-        }
+        // Server-side the flag is derived from last_login, which login already
+        // bumped — dismissing it locally is all that's left to do.
+        if (user?.is_first_login) setFirstLogin();
     };
 
     const startTest = (test) => {


### PR DESCRIPTION
Creating a room is now two steps: pick a mode, then set it up. Each mode gets a card with hand-built inline SVG art and a `?` that opens how it plays. Survival is shown but gated until its backend lands.

Teams adds a lobby sorter — tap a player then tap a team, with drag as a desktop extra, since HTML5 drag events never fire on touch and this is a phone-first feature. Team names are editable inline. Standings rank teams and break down who scored what.

Final Jeopardy adds a betting screen (slider plus None/¼/Half/All-in shortcuts) and states plainly that speed earns nothing on the final question. Scores can now go down, so the per-question delta renders red for a lost bet.

The post-question screen gains a collapsed answer spread and a "Review this question" card with the correct answer and explanation.

Drops the two calls to `update_first_login`, whose endpoint is being removed — the flag is derived from last_login server-side, so clearing it locally is all that was ever needed.