### PR TITLE
Give shared app links their own preview card

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,11 +46,28 @@ keeps them from drifting apart:
 2. `scripts/prerender.mjs` at build time — what link-preview crawlers see.
 3. The generated `sitemap.xml`.
 
-**Adding a public page:** add an entry to `src/seo/routes.js`, add the route in
+`routes.js` exports two lists:
+
+- **`SEO_ROUTES`** — public, indexable, in the sitemap.
+- **`SHARE_ROUTES`** — login-gated app routes people paste into Discord
+  (`/party`, `/study_guides`, `/tournaments`, …). Prerendered with the right OG
+  card but `noindex` and no canonical, and never in the sitemap. Without an
+  entry here a shared app URL falls back to `index.html` and previews as the
+  generic site card — which is the whole reason this list exists.
+
+**Adding a public page:** add an entry to `SEO_ROUTES`, add the route in
 `src/components/Router.jsx`, render `<SEO seoKey="yourKey"/>`, and link to it
 from `SATFooter` so it is reachable. The sitemap and prerendered HTML follow
-automatically. Private pages pass explicit props plus `noindex` and must NOT be
-listed in `routes.js`.
+automatically.
+
+**Dynamic invite links** (`/party/:roomId`, `/tournament/:id`) can't be
+prerendered per-instance, so `public/_redirects` maps those prefixes onto the
+matching share card. Serving another route's HTML is safe because every
+prerendered file is the same full SPA shell — React still reads the real URL.
+
+**robots.txt:** never `Disallow` a path that has a share card. Blocking the
+fetch hides the `noindex` from Google *and* stops X's card crawler from reading
+the OG tags. A test enforces this.
 
 **Why prerendering exists:** Discord, iMessage, Slack and X do not run
 JavaScript, so they only read the HTML the server returns. For an SPA that is

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,18 @@
+# Dynamic invite links get the card of the thing they invite you to.
+#
+# Netlify serves an existing file before applying any non-forced rule, so
+# /party and /party/history keep their own prerendered files (written by
+# scripts/prerender.mjs) and never reach these lines. Only a room code like
+# /party/A1B2C3 falls through to here.
+#
+# Serving another route's HTML is safe: every prerendered file is the same full
+# SPA shell, so React still reads the real URL and renders the right page. Only
+# the <head> differs, and that is exactly what the crawler came for.
+/party/*               /party/index.html         200
+/tournament/*          /tournaments/index.html   200
+/tournaments/join/*    /tournaments/index.html   200
+
+# SPA fallback for everything else.
 /* /index.html 200
+
 https://satduel.netlify.app/* https://satduel.com/:splat 301!

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,19 +1,41 @@
 User-agent: *
 Allow: /
 
+# The rule for app routes:
+#
+# - Route has an entry in SHARE_ROUTES (src/seo/routes.js)? Do NOT list it here.
+#   It is prerendered with `noindex`, which keeps it out of the index properly,
+#   and leaving it crawlable is what lets Discord and X's card crawler read its
+#   OG tags. Disallowing it here would block the fetch, so the noindex would
+#   never be read AND shared links would lose their preview.
+#
+# - No share card? It falls back to index.html, which claims index,follow and
+#   canonical "/", so it must be listed below or Google may index it as a
+#   duplicate of the home page.
+#
+# Crawlable with a noindex share card: /party, /party/history, /tournaments,
+# /study_guides, /infinite_questions, /practice_test, /ranking, /match.
+
 Disallow: /trainer
-Disallow: /infinite_questions
-Disallow: /match
 Disallow: /questions
-Disallow: /ranking
-Disallow: /profile
-Disallow: /settings
 Disallow: /upgrade
-Disallow: /admin
+Disallow: /profile
+Disallow: /messages
+Disallow: /settings
 Disallow: /shop
-Disallow: /duels
-Disallow: /practice_test
 Disallow: /classes
+Disallow: /my_tournaments
+Disallow: /create_tournament
+Disallow: /saved-questions
+Disallow: /practice-history
+Disallow: /mistake-review
+Disallow: /timed_challenges
+Disallow: /power_sprint
+Disallow: /sat_survival
+Disallow: /bot_training
+Disallow: /welcome
+Disallow: /complete_profile
+Disallow: /admin
 Disallow: /api/reset
 
 Sitemap: https://satduel.com/sitemap.xml

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -24,7 +24,7 @@ import {readFile, writeFile, mkdir} from 'node:fs/promises';
 import {join} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
-import {SEO_ROUTES, SITE_URL, SITE_NAME} from '../src/seo/routes.js';
+import {SEO_ROUTES, SHARE_ROUTES, SITE_URL, SITE_NAME} from '../src/seo/routes.js';
 
 const BUILD = fileURLToPath(new URL('../build', import.meta.url));
 
@@ -42,12 +42,18 @@ export function headFor(route) {
     const canonical = absolute(route.path);
     const image = absolute(route.image);
 
+    // Share cards are login-gated: they exist so a pasted link unfurls properly,
+    // not to be indexed. No canonical either — it would contradict noindex.
+    const indexing = route.noindex
+        ? '    <meta data-rh="true" name="robots" content="noindex,nofollow"/>'
+        : `    <meta data-rh="true" name="robots" content="index,follow"/>\n`
+          + `    <link data-rh="true" rel="canonical" href="${canonical}"/>`;
+
     // data-rh marks each tag as react-helmet-async's to own: on mount it
     // replaces these in place instead of appending a second, conflicting copy.
     // Without it every page ships two <link rel="canonical"> tags.
     return `    <meta data-rh="true" name="description" content="${description}"/>
-    <meta data-rh="true" name="robots" content="index,follow"/>
-    <link data-rh="true" rel="canonical" href="${canonical}"/>
+${indexing}
     <meta data-rh="true" property="og:site_name" content="${SITE_NAME}"/>
     <meta data-rh="true" property="og:type" content="${route.type || 'website'}"/>
     <meta data-rh="true" property="og:title" content="${title}"/>
@@ -98,7 +104,8 @@ ${urls}
 async function main() {
     const shell = await readFile(join(BUILD, 'index.html'), 'utf8');
 
-    for (const route of SEO_ROUTES) {
+    const shareRoutes = SHARE_ROUTES.map((r) => ({...r, noindex: true}));
+    for (const route of [...SEO_ROUTES, ...shareRoutes]) {
         if (route.path === '/') continue;  // that IS build/index.html
         const dir = join(BUILD, route.path);
         await mkdir(dir, {recursive: true});
@@ -109,9 +116,12 @@ async function main() {
     const home = SEO_ROUTES.find((r) => r.path === '/');
     await writeFile(join(BUILD, 'index.html'), render(shell, home));
 
+    // Only public routes belong in the sitemap; share cards are noindex.
     await writeFile(join(BUILD, 'sitemap.xml'), sitemap());
 
-    console.log(`prerendered ${SEO_ROUTES.length} routes + sitemap.xml`);
+    console.log(
+        `prerendered ${SEO_ROUTES.length} public + ${shareRoutes.length} share routes, + sitemap.xml`
+    );
 }
 
 // Importable for tests; only builds when run as a script.

--- a/src/seo/routes.js
+++ b/src/seo/routes.js
@@ -118,9 +118,82 @@ export const SEO_ROUTES = [
     {key: 'refunds', path: '/refund-policy', title: 'Refund and Cancellation Policy', description: 'How SAT Duel handles Premium cancellations and refund requests.', image: DEFAULT_IMAGE},
 ];
 
+/**
+ * Login-gated app routes that people actually paste into Discord.
+ *
+ * These are NOT indexable and never appear in the sitemap — they render behind
+ * the auth gate. But a shared link still gets unfurled, and without a
+ * prerendered file it falls through to index.html and previews as the generic
+ * site card. So they get the same treatment as public routes, minus the
+ * canonical, plus `noindex`.
+ *
+ * A share card is about what the link *is*, so the copy is written for someone
+ * who has just been handed the URL by a friend.
+ */
+export const SHARE_ROUTES = [
+    {
+        key: 'appParty',
+        path: '/party',
+        title: 'Join a live SAT party game',
+        description: 'Host a room or punch in a friend\'s code, then race each other through real Digital SAT questions with a live scoreboard.',
+        image: '/og/party.png',
+    },
+    {
+        key: 'appPartyHistory',
+        path: '/party/history',
+        title: 'SAT party game results',
+        description: 'Every room you have played, who won, and how each question went.',
+        image: '/og/party.png',
+    },
+    {
+        key: 'appTournaments',
+        path: '/tournaments',
+        title: 'SAT tournaments',
+        description: 'Join an SAT tournament, answer on your own schedule, and watch the live leaderboard.',
+        image: '/og/tournaments.png',
+    },
+    {
+        key: 'appStudyGuides',
+        path: '/study_guides',
+        title: 'SAT study guides',
+        description: 'Short Math and Reading & Writing lessons in the order you should learn them.',
+        image: '/og/studyGuide.png',
+    },
+    {
+        key: 'appPractice',
+        path: '/infinite_questions',
+        title: 'Practice Digital SAT questions',
+        description: 'One real question at a time, with a rating that moves as you answer and an explanation on every miss.',
+        image: '/og/practice.png',
+    },
+    {
+        key: 'appPracticeTest',
+        path: '/practice_test',
+        title: 'Full-length Digital SAT practice test',
+        description: 'Take an adaptive, full-length practice test under real timing and get a scored breakdown.',
+        image: '/og/practice.png',
+    },
+    {
+        key: 'appRanking',
+        path: '/ranking',
+        title: 'SAT Duel leaderboard',
+        description: 'See where you rank on Practice Elo, Duel Elo, and correct-answer streaks.',
+        image: '/og/tournaments.png',
+    },
+    {
+        // The default card is already duel-themed, so it fits without a variant.
+        key: 'appMatch',
+        path: '/match',
+        title: 'Duel someone at the Digital SAT',
+        description: 'Get matched against another student and answer the same questions head to head, in real time.',
+        image: '/og/default.png',
+    },
+];
+
 /** Look up one route's metadata by key. Throws early on a typo. */
 export function seoMeta(key) {
-    const found = SEO_ROUTES.find((r) => r.key === key);
+    const found = SEO_ROUTES.find((r) => r.key === key)
+        || SHARE_ROUTES.find((r) => r.key === key);
     if (!found) throw new Error(`Unknown SEO route key: ${key}`);
     return found;
 }

--- a/src/seo/routes.test.js
+++ b/src/seo/routes.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import {SEO_ROUTES, seoMeta} from './routes.js';
+import {SEO_ROUTES, SHARE_ROUTES, seoMeta} from './routes.js';
 import {headFor, render, sitemap} from '../../scripts/prerender.mjs';
 
 const SHELL = `<!DOCTYPE html>
@@ -16,7 +16,7 @@ const SHELL = `<!DOCTYPE html>
 </head><body><div id="root"></div></body></html>`;
 
 test('every route has the fields the prerenderer and sitemap need', () => {
-    for (const r of SEO_ROUTES) {
+    for (const r of [...SEO_ROUTES, ...SHARE_ROUTES]) {
         assert.ok(r.key, 'missing key');
         assert.match(r.path, /^\//, `${r.key}: path must be absolute`);
         assert.ok(r.title?.length, `${r.key}: missing title`);
@@ -25,11 +25,29 @@ test('every route has the fields the prerenderer and sitemap need', () => {
     }
 });
 
-test('paths and keys are unique', () => {
-    const paths = SEO_ROUTES.map((r) => r.path);
-    const keys = SEO_ROUTES.map((r) => r.key);
+test('paths and keys are unique across both lists', () => {
+    const all = [...SEO_ROUTES, ...SHARE_ROUTES];
+    const paths = all.map((r) => r.path);
+    const keys = all.map((r) => r.key);
     assert.equal(new Set(paths).size, paths.length, 'duplicate path');
     assert.equal(new Set(keys).size, keys.length, 'duplicate key');
+});
+
+test('share routes are noindex, carry no canonical, and stay out of the sitemap', () => {
+    const xml = sitemap();
+    for (const route of SHARE_ROUTES) {
+        const head = headFor({...route, noindex: true});
+        assert.ok(head.includes('content="noindex,nofollow"'), `${route.key}: not noindex`);
+        assert.ok(!head.includes('rel="canonical"'), `${route.key}: canonical contradicts noindex`);
+        assert.ok(head.includes(`content="https://satduel.com${route.image}"`), `${route.key}: wrong card`);
+        assert.ok(!xml.includes(`${route.path}</loc>`), `${route.key}: leaked into the sitemap`);
+    }
+});
+
+test('public routes stay indexable and keep their canonical', () => {
+    const head = headFor(seoMeta('partyGame'));
+    assert.ok(head.includes('content="index,follow"'));
+    assert.ok(head.includes('rel="canonical"'));
 });
 
 test('seoMeta throws on an unknown key rather than rendering blank tags', () => {
@@ -75,6 +93,20 @@ test('quotes in copy are escaped so they cannot break out of an attribute', () =
 
 test('render fails loudly if the markers are removed from index.html', () => {
     assert.throws(() => render('<html><head></head></html>', seoMeta('home')), /markers are missing/);
+});
+
+test('robots.txt does not block a route that has a share card', async () => {
+    const {readFile} = await import('node:fs/promises');
+    const robots = await readFile(new URL('../../public/robots.txt', import.meta.url), 'utf8');
+    const blocked = robots.split('\n')
+        .filter((l) => l.startsWith('Disallow:'))
+        .map((l) => l.replace('Disallow:', '').trim());
+
+    for (const route of SHARE_ROUTES) {
+        // Blocking the fetch would hide the noindex AND kill the link preview.
+        const hit = blocked.find((b) => route.path === b || route.path.startsWith(`${b}/`));
+        assert.equal(hit, undefined, `${route.path} has a share card but robots.txt blocks ${hit}`);
+    }
 });
 
 test('sitemap lists every route exactly once, absolute', () => {


### PR DESCRIPTION
The prerenderer only covered public marketing routes, so the URLs people actually paste into Discord — /party, /study_guides, /tournaments — had no static file, fell through to index.html, and previewed as the generic site card. Only /sat-party-game and friends worked, and nobody shares those.

Add SHARE_ROUTES: the same prerendering for eight login-gated app routes, with the matching card but noindex and no canonical, and never in the sitemap. They are not trying to rank; they are trying to unfurl.

Dynamic invites can't be prerendered per-instance, so _redirects maps /party/*, /tournament/* and /tournaments/join/* onto the matching card. Serving another route's HTML is safe here because every prerendered file is the same SPA shell — React still reads the real URL. Verified that a room link renders identically with and without the rule; only the <head> differs.

Also stop robots.txt from blocking /infinite_questions, /match, /ranking and /practice_test. Disallow blocks the fetch, so the noindex those pages now serve was never read, and X's card crawler could not see their OG tags either. Paths without a share card stay listed, because those still fall back to index.html and would otherwise look like duplicates of the home page. A test keeps the two lists from contradicting each other.