### PR TITLE
Update Premium copy to match what it actually gates, and unbreak /upg…

### DIFF
--- a/src/components/Router.jsx
+++ b/src/components/Router.jsx
@@ -139,7 +139,6 @@ const APP_ROUTES = [
     {path: '/practice_test', el: <PracticeTestPage/>},
     {path: '/classes', el: <ClassListPage/>},
     {path: '/settings', el: <SettingsPage/>},
-    {path: '/upgrade', el: <PricingPage/>},  // in-app pricing (keeps the shell)
     {path: '/admin', el: <AdminHomepage/>},
     {path: '/admin/announcement', el: <AnnouncementPage/>},
     {path: '/admin/question_reports', el: <QuestionReportsPage/>},
@@ -192,6 +191,13 @@ function Router() {
             {FULLSCREEN_ROUTES.map((r) => (
                 <Route key={r.path} path={r.path} element={S(r.el)}/>
             ))}
+
+            {/* /upgrade used to render PricingPage inside AppLayout. That shell has
+                no .sd-landing wrapper, so the page's --sd-* tokens resolved to
+                nothing and its hero lost its background, borders, and text color.
+                Pricing belongs to the public zone; send in-app upgrade links there
+                instead of maintaining one page that has to work in both. */}
+            <Route path="/upgrade" element={<Navigate to="/pricing" replace/>}/>
         </Routes>
     );
 }

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1021,31 +1021,36 @@ function Pricing() {
                     Free to duel. Cheap to go unlimited.
                 </h2>
                 <div className="mt-12 grid gap-5 md:grid-cols-2">
-                    <div className={`${panelCls} rounded-[18px] p-7`}>
+                    {/* Cards are uneven now that Premium lists more; align the tops. */}
+                    <div className={`${panelCls} flex flex-col rounded-[18px] p-7`}>
                         <span className={`${MONO} text-xs tracking-[0.1em] text-[var(--sd-violet-lbl)]`}>FREE</span>
                         <div className="mt-3 flex items-baseline gap-2">
                             <span className="sd-display text-[44px] font-bold text-[var(--sd-text)]">$0</span>
                             <span className="text-sm text-[var(--sd-dim)]">forever</span>
                         </div>
-                        <div className="mt-5 flex flex-col gap-2.5 text-[14.5px] text-[var(--sd-mut2)]">
+                        <div className="mt-5 flex flex-1 flex-col gap-2.5 text-[14.5px] text-[var(--sd-mut2)]">
                             <span>✓&nbsp;&nbsp;25 questions a day</span>
-                            <span>✓&nbsp;&nbsp;Duels and practice tests</span>
-                            <span>✓&nbsp;&nbsp;Diagnostic score estimate</span>
+                            <span>✓&nbsp;&nbsp;Duels, tournaments and practice tests</span>
+                            <span>✓&nbsp;&nbsp;Party rooms up to 6 players</span>
+                            <span>✓&nbsp;&nbsp;Every Reading &amp; Writing lesson</span>
                         </div>
                         <Link to="/register" className="mt-[26px] block rounded-[11px] border-[1.5px] border-[var(--sd-line3)] py-[13px] text-center text-[15px] font-bold text-[var(--sd-body)] no-underline transition-colors hover:border-[#A78BFA] hover:text-[var(--sd-text)]">
                             Start Free
                         </Link>
                     </div>
-                    <div className={`relative rounded-[18px] border-[1.5px] border-[rgba(233,188,79,0.55)] bg-[var(--sd-panel)] p-7 shadow-[0_0_0_4px_rgba(233,188,79,0.07)]`}>
+                    <div className={`relative flex flex-col rounded-[18px] border-[1.5px] border-[rgba(233,188,79,0.55)] bg-[var(--sd-panel)] p-7 shadow-[0_0_0_4px_rgba(233,188,79,0.07)]`}>
                         <span className={`${MONO} absolute -top-3 right-[22px] rounded-md bg-[#E9BC4F] px-2.5 py-1 text-[10.5px] tracking-[0.08em] text-[#1F1204]`}>MOST POPULAR</span>
                         <span className={`${MONO} text-xs tracking-[0.1em] text-[var(--sd-gold-lbl)]`}>PREMIUM</span>
                         <div className="mt-3 flex items-baseline gap-2">
                             <span className="sd-display text-[44px] font-bold text-[var(--sd-text)]">$9.99</span>
                             <span className="text-sm text-[var(--sd-dim)]">per month</span>
                         </div>
-                        <div className="mt-5 flex flex-col gap-2.5 text-[14.5px] text-[var(--sd-mut2)]">
+                        <div className="mt-5 flex flex-1 flex-col gap-2.5 text-[14.5px] text-[var(--sd-mut2)]">
                             <span>✓&nbsp;&nbsp;Unlimited practice</span>
                             <span>✓&nbsp;&nbsp;Choose the exact topics you drill</span>
+                            <span>✓&nbsp;&nbsp;Party rooms up to 50 players, 50 questions</span>
+                            <span>✓&nbsp;&nbsp;The full Math study guide library</span>
+                            <span>✓&nbsp;&nbsp;Premium crown on the leaderboard</span>
                             <span>✓&nbsp;&nbsp;Everything in Free</span>
                         </div>
                         <Link to="/pricing" className="mt-[26px] block rounded-[11px] bg-[#7C5CF0] py-[13px] text-center text-[15px] font-bold text-white no-underline shadow-[0_6px_20px_rgba(124,92,240,0.4)] transition-colors hover:bg-[#9678FF]">

--- a/src/pages/PricingPage.jsx
+++ b/src/pages/PricingPage.jsx
@@ -9,7 +9,7 @@ import {
     FileText,
     Gauge,
     Lock,
-    ShieldCheck,
+    PartyPopper,
     Sparkles,
     Target,
     Trophy,
@@ -21,18 +21,29 @@ import {useAuth} from '../context/AuthContext';
 import {billingErrorMessage, openBillingPortal, startPremiumCheckout} from '../utils/billing';
 import SEO, {breadcrumbJsonLd, faqJsonLd, softwareAppJsonLd} from '../components/SEO';
 
+// Every line below maps to a real gate in the code. Keep it that way — this is
+// the page people pay from.
+//   daily cap ......... settings.FREE_DAILY_LIMIT (25)
+//   topic selection ... api/views/practice_views.py filters_are_default()
+//   party sizes ....... api/views/party_views.py CAPS
+//   gold rush pool .... api/views/party_views.py GOLD_POOL (30 vs 100)
+//   math guides ....... src/pages/StudyGuidePage.jsx isLocked()
+//   crown ............. RankingPage / ProfilePage render it off is_premium
 const FREE_FEATURES = [
     '25 adaptive practice questions each day',
     'Random topic mix from the SAT bank',
-    'Two-minute diagnostic estimate',
-    'Duels, tournaments, and practice tests',
+    'Party rooms with up to 6 friends, 20 questions a game',
+    'Duels, tournaments, and full-length practice tests',
+    'Every Reading and Writing study guide lesson',
 ];
 
 const PREMIUM_FEATURES = [
-    'Unlimited adaptive practice',
-    'Choose exact SAT question topics',
-    'Keep diagnostic and progress history',
-    'Stripe subscription, invoices, and billing portal',
+    'Unlimited adaptive practice — no daily cap',
+    'Choose the exact SAT topics you drill',
+    'Party rooms up to 50 players and 50 questions a game',
+    'A deeper Gold Rush pool, so questions repeat far less',
+    'The complete Math study guide library',
+    'A Premium crown on your profile and the leaderboard',
 ];
 
 const SCORE_SIGNALS = [
@@ -44,15 +55,19 @@ const SCORE_SIGNALS = [
 const FAQS = [
     {
         question: 'Can I keep using SAT Duel for free?',
-        answer: 'Yes. Free users still get daily practice, the diagnostic, duels, tournaments, and practice tests.',
+        answer: 'Yes, and free is genuinely usable. You get 25 questions a day, the diagnostic, duels, tournaments, full-length practice tests, party rooms up to six players, and the whole Reading and Writing study guide.',
     },
     {
         question: 'What does Premium unlock first?',
-        answer: 'Premium removes the daily practice cap and unlocks topic selection so students can drill the exact skills they need.',
+        answer: 'The daily cap disappears and you can pick exact topics to drill. After that it scales up the social side: party rooms go from 6 players to 50, and games from 20 questions to 50.',
+    },
+    {
+        question: 'Does Premium change party games?',
+        answer: 'Yes. A Premium host can run a room for up to 50 players with up to 50 questions, and Gold Rush draws from a much larger pool so questions repeat far less over a long game. Guests never need Premium to join.',
     },
     {
         question: 'Where are payments handled?',
-        answer: 'Checkout, invoices, and subscription management are handled by Stripe.',
+        answer: 'Checkout, invoices, and subscription management are handled by Stripe. You can cancel any time from the billing portal.',
     },
 ];
 
@@ -222,10 +237,10 @@ function PricingPage() {
                             Free forever. $9.99/month to go unlimited.
                         </h1>
                         <p className="mx-auto mt-4 max-w-2xl text-lg leading-relaxed text-[var(--sd-mut)]">
-                            Free gives you 25 adaptive questions a day plus duels, tournaments, and practice tests. Premium removes the daily cap and lets you pick the exact topics you drill.
+                            Free gives you 25 adaptive questions a day plus duels, tournaments, practice tests, and party rooms. Premium removes the daily cap, lets you pick the exact topics you drill, and scales your party rooms to a full classroom.
                         </p>
                         <div className="mt-6 flex flex-wrap justify-center gap-2">
-                            {['Unlimited practice', 'Topic selection', 'Cancel anytime'].map((label) => (
+                            {['Unlimited practice', 'Topic selection', '50-player parties', 'Cancel anytime'].map((label) => (
                                 <span key={label} className="rounded-full border border-[var(--sd-line2)] bg-[var(--sd-panel)] px-3 py-1.5 text-sm font-black text-[var(--sd-mut2)]">
                                     {label}
                                 </span>
@@ -240,8 +255,10 @@ function PricingPage() {
                     )}
 
                     <div className="mx-auto mt-8 grid max-w-5xl gap-5 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
-                        <Card className="sat-arena-card overflow-hidden">
-                            <div className="p-6">
+                        {/* Premium lists more features, so the grid row is taller than
+                            this card's content — grow the body to keep the CTA on the floor. */}
+                        <Card className="sat-arena-card flex flex-col overflow-hidden">
+                            <div className="flex-1 p-6">
                                 <div className="flex items-center gap-3">
                                     <div className="flex size-11 items-center justify-center rounded-2xl bg-slate-100 text-slate-600">
                                         <Zap className="size-5"/>
@@ -337,10 +354,10 @@ function PricingPage() {
                     <div>
                         <p className="m-0 text-xs font-black uppercase text-[var(--sd-violet-lbl)]">Why upgrade</p>
                         <h2 className="m-0 mt-3 font-display text-3xl font-black leading-tight text-[var(--sd-text)] sm:text-4xl">
-                            Premium changes exactly two things.
+                            More reps, aimed better, with more friends.
                         </h2>
                         <p className="m-0 mt-4 text-lg leading-relaxed text-[var(--sd-mut)]">
-                            The 25-question daily cap goes away, and you choose which topics you drill instead of getting a random mix. Everything else — duels, tournaments, practice tests, the diagnostic — stays free.
+                            The 25-question daily cap goes away, you pick the topics you drill instead of taking a random mix, and your party rooms grow from 6 players to 50. Duels, tournaments, practice tests, and the diagnostic stay free for everyone.
                         </p>
                     </div>
 
@@ -365,10 +382,10 @@ function PricingPage() {
                         </p>
                     </Card>
                     <Card className="sat-arena-card p-5">
-                        <ShieldCheck className="mb-4 size-7 text-emerald-700"/>
-                        <h3 className="m-0 font-display text-lg font-black text-slate-950">Clean billing</h3>
+                        <PartyPopper className="mb-4 size-7 text-emerald-700"/>
+                        <h3 className="m-0 font-display text-lg font-black text-slate-950">Bigger parties</h3>
                         <p className="m-0 mt-2 text-sm leading-relaxed text-slate-600">
-                            Stripe handles checkout, invoices, and subscription management.
+                            Host a whole class instead of a group chat: 50 players, 50 questions, and far fewer repeats.
                         </p>
                     </Card>
                 </div>

--- a/src/seo/routes.js
+++ b/src/seo/routes.js
@@ -101,7 +101,7 @@ export const SEO_ROUTES = [
         key: 'pricing',
         path: '/pricing',
         title: 'SAT Duel Pricing',
-        description: 'Start SAT Duel for free or upgrade to Premium for unlimited Digital SAT practice and focused topic selection.',
+        description: 'Start SAT Duel free with 25 questions a day, duels, tournaments, and party rooms. Premium adds unlimited practice, topic selection, 50-player parties, and the full Math study guide.',
         image: '/og/default.png',
     },
     {


### PR DESCRIPTION
…rade

The plan copy was written before party mode and the study guides shipped, so it undersold Premium: it listed the billing portal as a feature and never mentioned that a Premium host gets 50-player rooms.

Both plan lists now describe real gates, with a comment tying each line to the code that enforces it so the page cannot drift again:

  daily cap ...... settings.FREE_DAILY_LIMIT (25)
  topic filters .. practice_views.filters_are_default()
  party sizes .... party_views.CAPS (6/20 free, 50/50 premium)
  gold rush ...... party_views.GOLD_POOL (30 vs 100)
  math guides .... StudyGuidePage.isLocked()
  crown .......... RankingPage / ProfilePage read is_premium

Same lists on the landing page's plan boxes. Both cards there now flex so the CTAs stay aligned once Premium lists six items and Free lists four.

The style mismatch had a specific cause: /upgrade rendered PricingPage inside AppLayout, which has no .sd-landing wrapper, so every --sd-* token on the page resolved to nothing — the hero lost its background, its border, and its text color, and in dark mode headings came out near-black on a dark ground. One page cannot serve both shells. Pricing belongs to the public zone, so /upgrade is now a redirect to /pricing and the four in-app links keep working unchanged.